### PR TITLE
feat: add force option to skip existing dependency downloads

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 # bashunit
 BASHUNIT_DEFAULT_PATH="tests"
 BASHUNIT_LOAD_FILE="tests/bootstrap.sh"
-BASHUNIT_LOG_PATH=local/out.log
+BASHUNIT_DEV_LOG=local/out.log

--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Alternately, you can configure the default values of bashdep using the setup fun
 - `dir=string`: set the default destination directory. Default: `lib`
 - `dev-dir=string`: set the development destination directory. Default: `lib/dev`
 - `silent=bool`: if true, no progress text will be shown during installation. Default: `false`
+- `force=bool`: if true, download the dependency even when it already exists. Default: `false`
 
 ```bash
-bashdep::setup dir="lib" dev-dir="src/dev" silent=false
+bashdep::setup dir="lib" dev-dir="src/dev" silent=false force=false
 bashdep::install "${DEPENDENCIES[@]}"
 ```
 
@@ -53,7 +54,7 @@ DEPENDENCIES=(
 )
 
 source lib/bashdep
-bashdep::setup dir="lib" dev-dir="src/dev" silent=false
+bashdep::setup dir="lib" dev-dir="src/dev" silent=false force=false
 bashdep::install "${DEPENDENCIES[@]}"
 ```
 

--- a/bashdep
+++ b/bashdep
@@ -4,16 +4,18 @@ BASHDEP_DIR="lib"
 BASHDEP_DEV_DIR="lib/dev"
 BASHDEP_DEV_SUFFIX="@dev"
 BASHDEP_SILENT=false
+BASHDEP_FORCE=false
 
 # Configure destination directories and silent mode.
 #
 # Usage:
-#   bashdep::setup [dir=DIR] [dev-dir=DEV_DIR] [silent=true|false]
+#   bashdep::setup [dir=DIR] [dev-dir=DEV_DIR] [silent=true|false] [force=true|false]
 #
 # Parameters:
 #       dir    - Set the default destination directory.
 #   dev-dir    - Set the development destination directory.
 #   silent     - If true, no progress text will be shown during installation.
+#   force      - If true, re-download dependencies even if they already exist.
 #
 # Example:
 #   bashdep::setup dir="vendor" dev-dir="src/dev" silent=true
@@ -23,6 +25,7 @@ function bashdep::setup() {
       dir=*)       BASHDEP_DIR="${param#*=}"        ;;
       dev-dir=*)   BASHDEP_DEV_DIR="${param#*=}"    ;;
       silent=*)    BASHDEP_SILENT="${param#*=}"     ;;
+      force=*)     BASHDEP_FORCE="${param#*=}"      ;;
       *)
         echo "Error: Invalid parameter '$param'"
         return 1
@@ -70,6 +73,13 @@ function bashdep::download_url() {
   file_name=$(basename "$url")
   local destination_file="$destination_dir/$file_name"
 
+  if [[ -f "$destination_file" ]] && ! bashdep::is_force; then
+    if ! bashdep::is_silent; then
+      echo "> $file_name already exists in '$destination_dir', skipping."
+    fi
+    return 0
+  fi
+
   if ! bashdep::is_silent; then
     echo "Downloading '$file_name' to '$destination_dir'..."
   fi
@@ -87,4 +97,8 @@ function bashdep::download_url() {
 
 function bashdep::is_silent() {
   [ "$BASHDEP_SILENT" == true ]
+}
+
+function bashdep::is_force() {
+  [ "$BASHDEP_FORCE" == true ]
 }

--- a/example/demo.sh
+++ b/example/demo.sh
@@ -9,5 +9,5 @@ DEPENDENCIES=(
   "https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh@dev"
 )
 
-bashdep::setup dir="vendor" dev-dir="local/dev" silent=false
+bashdep::setup dir="vendor" dev-dir="local/dev" silent=false force=false
 bashdep::install "${DEPENDENCIES[@]}"

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -50,8 +50,22 @@ function test_bashdep_download_url_custom_dir() {
   local url="https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit"
   local dir="/tmp/test_bashdep_download_url_custom_dir"
 
+  mkdir -p "$dir"
   mock curl "echo mocked curl"
 
   assert_match_snapshot "$(bashdep::download_url "$url" "$dir")"
-  rmdir "$dir"
+  rm -rf "$dir"
+}
+
+function test_bashdep_download_url_skip_when_exists() {
+  local url="https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit"
+  local dir="/tmp/test_bashdep_download_url_skip_when_exists"
+  local file="$dir/bashunit"
+
+  mkdir -p "$dir"
+  touch "$file"
+  mock curl "echo mocked curl"
+
+  assert_match_snapshot "$(bashdep::download_url "$url" "$dir")"
+  rm -rf "$dir"
 }

--- a/tests/unit/snapshots/bashdep_test_sh.test_bashdep_download_url_skip_when_exists.snapshot
+++ b/tests/unit/snapshots/bashdep_test_sh.test_bashdep_download_url_skip_when_exists.snapshot
@@ -1,0 +1,1 @@
+> bashunit already exists in '/tmp/test_bashdep_download_url_skip_when_exists', skipping.


### PR DESCRIPTION
## Summary
- Adds `force=bool` setup option (default `false`). When false, `bashdep::download_url` skips downloads when the file already exists in the destination dir and prints a notice.
- Fixes broken conditional `[[ -f file && ! bashdep::is_force ]]` — function calls cannot be evaluated inside `[[ ]]`. Use compound `[[ -f file ]] && ! bashdep::is_force` instead.
- Hardens `download_url` tests so they pass under both bashunit 0.17.0 (CI) and 0.21.0 (stricter `set -e`): explicitly `mkdir -p` destination dirs and use `rm -rf` for cleanup.
- Renames `BASHUNIT_LOG_PATH` → `BASHUNIT_DEV_LOG` in `.env`.

## Test plan
- [x] `make test` — all 6 tests pass locally on bashunit 0.21.0
- [x] Tests pass on bashunit 0.17.0 (CI version)
- [x] ShellCheck clean
- [x] editorconfig-checker clean
- [ ] CI green on PR