### PR TITLE
chore: A+ DX — error handling, validation, and docs overhaul

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,11 +43,11 @@ use with Git. Strings such as `silly nick name <root@localhost>` looks bad in th
 
 ## Development
 
-- Entry point `bashdep.sh`
+- Entry point: `bashdep` (sourced by consumers as a library).
 
 ## Testing
 
-Install dependencies: `./install-dependencies.sh`
+Install dependencies: `make deps` (or `./install-dependencies.sh`).
 
 Run tests:
 

--- a/README.md
+++ b/README.md
@@ -1,51 +1,55 @@
 # bashdep
 
-A minimalistic and straightforward **bash dependency manager**.
+[![Tests](https://github.com/Chemaclass/bashdep/actions/workflows/tests.yml/badge.svg)](https://github.com/Chemaclass/bashdep/actions/workflows/tests.yml)
+[![Static Analysis](https://github.com/Chemaclass/bashdep/actions/workflows/static_analysis.yml/badge.svg)](https://github.com/Chemaclass/bashdep/actions/workflows/static_analysis.yml)
+[![Lint](https://github.com/Chemaclass/bashdep/actions/workflows/linter.yml/badge.svg)](https://github.com/Chemaclass/bashdep/actions/workflows/linter.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
----
+A minimalistic, zero-dependency **bash dependency manager**. Declare a list of
+URLs and bashdep will download them into a `lib/` directory you can `source`
+from your scripts.
 
-### Usage
+## Contents
 
-#### bashdep::install
+- [Why bashdep?](#why-bashdep)
+- [Install](#install)
+- [Quick start](#quick-start)
+- [API](#api)
+  - [`bashdep::install`](#bashdepinstall)
+  - [`bashdep::setup`](#bashdepsetup)
+  - [`bashdep::version`](#bashdepversion)
+- [Behavior](#behavior)
+  - [Skip vs. force re-download](#skip-vs-force-re-download)
+  - [Dev dependencies](#dev-dependencies)
+  - [Error handling](#error-handling)
+- [Development](#development)
 
-You can distinguish between regular dependencies and dev-dependencies when defining the URL.
-Dev-dependencies ends with `@dev`
+## Why bashdep?
+
+Most bash projects vendor scripts by hand: `curl`, `chmod +x`, repeat. bashdep
+turns that into one declarative list with sensible defaults: idempotent
+installs, dev/prod separation via the `@dev` suffix, and a single `force` flag
+to force a refresh. No package registry, no lockfile, no runtime — just `curl`.
+
+## Install
+
+Drop the `bashdep` script into your repo (typically under `lib/`):
 
 ```bash
-DEPENDENCIES=(
-  "https://github.com/[...]/download/0.17.0/bashunit"
-  "https://github.com/[...]/download/0.1/dumper.sh@dev"
-)
-
-bashdep::install "${DEPENDENCIES[@]}"
+mkdir -p lib
+curl -fsSLo lib/bashdep https://raw.githubusercontent.com/Chemaclass/bashdep/main/bashdep
+chmod +x lib/bashdep
 ```
 
-#### bashdep::setup
+Then `source lib/bashdep` from your install script.
 
-Alternately, you can configure the default values of bashdep using the setup function.
-
-- `dir=string`: set the default destination directory. Default: `lib`
-- `dev-dir=string`: set the development destination directory. Default: `lib/dev`
-- `silent=bool`: if true, no progress text will be shown during installation. Default: `false`
-- `force=bool`: if true, download the dependency even when it already exists. Default: `false`
-
-```bash
-bashdep::setup dir="lib" dev-dir="src/dev" silent=false force=false
-bashdep::install "${DEPENDENCIES[@]}"
-```
-
-### Demo
-
-Usage example from
-[Chemaclass/bash-skeleton](https://github.com/Chemaclass/bash-skeleton/blob/main/install-dependencies.sh)
+## Quick start
 
 ```bash
 #!/bin/bash
-[ ! -f lib/bashdep ] && {
-  mkdir -p lib
-  curl -sLo lib/bashdep https://github.com/Chemaclass/bashdep/releases/download/0.1/bashdep
-  chmod +x lib/bashdep
-}
+set -euo pipefail
+
+source lib/bashdep
 
 DEPENDENCIES=(
   "https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit"
@@ -53,42 +57,112 @@ DEPENDENCIES=(
   "https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh@dev"
 )
 
-source lib/bashdep
-bashdep::setup dir="lib" dev-dir="src/dev" silent=false force=false
 bashdep::install "${DEPENDENCIES[@]}"
 ```
 
-#### Output
+Run it, and bashdep prints:
 
-```bash
+```
 Downloading 'bashunit' to 'lib'...
 > bashunit installed successfully in 'lib'
 Downloading 'create-pr' to 'lib'...
 > create-pr installed successfully in 'lib'
-Downloading 'dumper.sh' to 'src/dev'...
-> dumper.sh installed successfully in 'src/dev'
+Downloading 'dumper.sh' to 'lib/dev'...
+> dumper.sh installed successfully in 'lib/dev'
 ```
 
-### Development
+Re-run it and previously-installed files are skipped:
 
-Install required dependencies to run the tests:
+```
+> bashunit already exists in 'lib', skipping.
+```
+
+## API
+
+### `bashdep::install`
+
+Download every dependency in the list into the configured directories.
+
+```bash
+bashdep::install "${DEPENDENCIES[@]}"
+```
+
+Returns the number of failed downloads (0 on success). Pair with
+`set -e` or check `$?` to gate the rest of your script.
+
+### `bashdep::setup`
+
+Configure defaults before calling `install`. All parameters are optional.
+
+| Param     | Type   | Default   | Purpose                                                |
+| --------- | ------ | --------- | ------------------------------------------------------ |
+| `dir`     | string | `lib`     | Destination for normal dependencies.                   |
+| `dev-dir` | string | `lib/dev` | Destination for dev dependencies (URLs ending `@dev`). |
+| `silent`  | bool   | `false`   | Suppress progress output.                              |
+| `force`   | bool   | `false`   | Re-download even when the file already exists.         |
+
+```bash
+bashdep::setup dir="vendor" dev-dir="src/dev" silent=true force=false
+```
+
+Invalid values (unknown param, non-boolean for `silent`/`force`) cause
+`setup` to print an error to stderr and return `1`.
+
+### `bashdep::version`
+
+Print the bashdep version.
+
+```bash
+bashdep::version  # 0.2.0
+```
+
+## Behavior
+
+### Skip vs. force re-download
+
+By default `bashdep::install` is idempotent: if a destination file already
+exists, the download is skipped. Pass `force=true` to refresh:
+
+```bash
+bashdep::setup force=true
+bashdep::install "${DEPENDENCIES[@]}"
+```
+
+### Dev dependencies
+
+A URL ending in `@dev` is treated as a development-only dependency and
+installed into `dev-dir` instead of `dir`:
+
+```bash
+DEPENDENCIES=(
+  "https://example.com/runtime.sh"          # → lib/
+  "https://example.com/dev-tool.sh@dev"     # → lib/dev/
+)
+```
+
+### Error handling
+
+- `download_url` returns `1` and prints to stderr on `curl` failure or missing URL.
+- `install` keeps going through the list and returns the number of failures.
+- `setup_directory` returns `1` if it cannot create the destination dir.
+
+Use `set -e` plus `bashdep::install ... || exit $?` to fail fast in scripts.
+
+## Development
+
+Install test dependencies (bashunit) and run the suite:
 
 ```bash
 make deps
-```
-
-Then run the test suite and linters:
-
-```bash
 make test
-make sa
-make lint
 ```
 
-To enable automatic checks before each commit install the pre-commit hook:
+Other targets:
 
 ```bash
+make sa                # ShellCheck static analysis
+make lint              # editorconfig-checker
 make pre_commit/install
 ```
 
-For more details see [CONTRIBUTING](.github/CONTRIBUTING.md).
+See [CONTRIBUTING](.github/CONTRIBUTING.md) for the full contributor guide.

--- a/bashdep
+++ b/bashdep
@@ -1,21 +1,27 @@
 #!/bin/bash
 
+BASHDEP_VERSION="0.2.0"
 BASHDEP_DIR="lib"
 BASHDEP_DEV_DIR="lib/dev"
 BASHDEP_DEV_SUFFIX="@dev"
 BASHDEP_SILENT=false
 BASHDEP_FORCE=false
 
-# Configure destination directories and silent mode.
+# Print bashdep version.
+function bashdep::version() {
+  echo "$BASHDEP_VERSION"
+}
+
+# Configure bashdep behavior.
 #
 # Usage:
 #   bashdep::setup [dir=DIR] [dev-dir=DEV_DIR] [silent=true|false] [force=true|false]
 #
 # Parameters:
-#       dir    - Set the default destination directory.
-#   dev-dir    - Set the development destination directory.
-#   silent     - If true, no progress text will be shown during installation.
-#   force      - If true, re-download dependencies even if they already exist.
+#       dir    - Default destination directory (default: lib).
+#   dev-dir    - Development destination directory (default: lib/dev).
+#   silent     - Suppress progress output (default: false).
+#   force      - Re-download dependencies even if they already exist (default: false).
 #
 # Example:
 #   bashdep::setup dir="vendor" dev-dir="src/dev" silent=true
@@ -24,20 +30,21 @@ function bashdep::setup() {
     case $param in
       dir=*)       BASHDEP_DIR="${param#*=}"        ;;
       dev-dir=*)   BASHDEP_DEV_DIR="${param#*=}"    ;;
-      silent=*)    BASHDEP_SILENT="${param#*=}"     ;;
-      force=*)     BASHDEP_FORCE="${param#*=}"      ;;
+      silent=*)    bashdep::_set_bool BASHDEP_SILENT "${param#*=}" silent || return 1 ;;
+      force=*)     bashdep::_set_bool BASHDEP_FORCE "${param#*=}" force  || return 1 ;;
       *)
-        echo "Error: Invalid parameter '$param'"
+        echo "Error: Invalid parameter '$param'" >&2
         return 1
         ;;
     esac
   done
 }
 
-# Download and install all dependencies
+# Download and install all dependencies.
+# Returns 0 if all succeed, otherwise the number of failures.
 function bashdep::install() {
   local dependencies=("$@")
-  local url destination_dir
+  local url destination_dir failures=0
 
   for dep in "${dependencies[@]}"; do
     if [[ "$dep" == *"$BASHDEP_DEV_SUFFIX" ]]; then
@@ -48,27 +55,43 @@ function bashdep::install() {
       destination_dir="$BASHDEP_DIR"
     fi
 
-    bashdep::setup_directory "$destination_dir"
-    bashdep::download_url "$url" "$destination_dir"
+    bashdep::setup_directory "$destination_dir" || { failures=$((failures + 1)); continue; }
+    bashdep::download_url "$url" "$destination_dir" || failures=$((failures + 1))
   done
+
+  return "$failures"
 }
 
-# Ensure destination directory exists, and create it if missing
+# Ensure destination directory exists. Create it if missing.
+# Returns 1 if the directory cannot be created.
 function bashdep::setup_directory() {
   local destination_dir=$1
 
+  if [[ -z "$destination_dir" ]]; then
+    echo "Error: setup_directory requires a directory argument." >&2
+    return 1
+  fi
+
   if [[ ! -d "$destination_dir" ]]; then
-    mkdir -p "$destination_dir" || {
-      echo "Error: Could not create directory '$destination_dir'. Exiting."
-      exit 1
-    }
+    if ! mkdir -p "$destination_dir"; then
+      echo "Error: Could not create directory '$destination_dir'." >&2
+      return 1
+    fi
   fi
 }
 
-# Download URL to the destination directory
+# Download a URL to the destination directory.
+# Skips when the file already exists, unless force=true is configured.
+# Returns 1 on missing URL or curl failure.
 function bashdep::download_url() {
   local url=$1
   local destination_dir=${2:-$BASHDEP_DIR}
+
+  if [[ -z "$url" ]]; then
+    echo "Error: download_url requires a URL argument." >&2
+    return 1
+  fi
+
   local file_name
   file_name=$(basename "$url")
   local destination_file="$destination_dir/$file_name"
@@ -84,13 +107,13 @@ function bashdep::download_url() {
     echo "Downloading '$file_name' to '$destination_dir'..."
   fi
 
-  if curl -s -L "$url" -o "$destination_file"; then
+  if curl -fsSL "$url" -o "$destination_file"; then
     if ! bashdep::is_silent; then
       echo "> $file_name installed successfully in '$destination_dir'"
     fi
     chmod +x "$destination_file"
   else
-    echo "Error: Failed to install $file_name from $url"
+    echo "Error: Failed to install $file_name from $url" >&2
     return 1
   fi
 }
@@ -101,4 +124,16 @@ function bashdep::is_silent() {
 
 function bashdep::is_force() {
   [ "$BASHDEP_FORCE" == true ]
+}
+
+# Internal: validate and assign a boolean variable.
+function bashdep::_set_bool() {
+  local var_name=$1 raw=$2 label=$3
+  case "$raw" in
+    true|false) printf -v "$var_name" '%s' "$raw" ;;
+    *)
+      echo "Error: '$label' must be 'true' or 'false', got '$raw'" >&2
+      return 1
+      ;;
+  esac
 }

--- a/example/demo.sh
+++ b/example/demo.sh
@@ -9,5 +9,5 @@ DEPENDENCIES=(
   "https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh@dev"
 )
 
-bashdep::setup dir="vendor" dev-dir="local/dev" silent=false force=false
-bashdep::install "${DEPENDENCIES[@]}"
+bashdep::setup dir="vendor" dev-dir="local/dev"
+bashdep::install "${DEPENDENCIES[@]}" || exit $?

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "Installing test dependencies via bashunit installer..."
-curl -fsSL https://bashunit.typeddevs.com/install.sh | bash
+# Pin to the same bashunit version used in CI (.github/workflows/tests.yml).
+BASHUNIT_VERSION="${BASHUNIT_VERSION:-0.17.0}"
+
+echo "Installing bashunit ${BASHUNIT_VERSION} into lib/..."
+curl -fsSL https://bashunit.typeddevs.com/install.sh | bash -s lib "${BASHUNIT_VERSION}"

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -7,7 +7,7 @@ function set_up() {
 }
 
 function test_bashdep_install_custom_setup() {
-  mock bashdep::setup_directory "/dev/null"
+  mock bashdep::setup_directory "return 0"
   mock bashdep::download_url "echo mocked download_url"
   bashdep::setup dir="vendor" dev-dir="src/dev" silent=true
 
@@ -21,7 +21,7 @@ function test_bashdep_install_custom_setup() {
 }
 
 function test_bashdep_install_default_setup() {
-  mock bashdep::setup_directory "/dev/null"
+  mock bashdep::setup_directory "return 0"
   mock bashdep::download_url "echo mocked download_url"
 
   local DEPENDENCIES=(
@@ -68,4 +68,47 @@ function test_bashdep_download_url_skip_when_exists() {
 
   assert_match_snapshot "$(bashdep::download_url "$url" "$dir")"
   rm -rf "$dir"
+}
+
+function test_bashdep_download_url_force_redownload() {
+  local url="https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit"
+  local dir="/tmp/test_bashdep_download_url_force_redownload"
+  local file="$dir/bashunit"
+
+  mkdir -p "$dir"
+  touch "$file"
+  mock curl "echo mocked curl"
+  bashdep::setup force=true
+
+  assert_match_snapshot "$(bashdep::download_url "$url" "$dir")"
+  rm -rf "$dir"
+}
+
+function test_bashdep_setup_rejects_invalid_bool() {
+  bashdep::setup silent=maybe 2>/dev/null
+  assert_general_error
+}
+
+function test_bashdep_setup_rejects_unknown_param() {
+  bashdep::setup unknown=value 2>/dev/null
+  assert_general_error
+}
+
+function test_bashdep_download_url_requires_url() {
+  bashdep::download_url "" "/tmp" 2>/dev/null
+  assert_general_error
+}
+
+function test_bashdep_install_returns_failure_count() {
+  mock bashdep::setup_directory "return 0"
+  mock bashdep::download_url "return 1"
+
+  bashdep::install "https://example.com/a" "https://example.com/b"
+  local rc=$?
+
+  assert_equals 2 "$rc"
+}
+
+function test_bashdep_version_is_set() {
+  assert_not_empty "$(bashdep::version)"
 }

--- a/tests/unit/snapshots/bashdep_test_sh.test_bashdep_download_url_force_redownload.snapshot
+++ b/tests/unit/snapshots/bashdep_test_sh.test_bashdep_download_url_force_redownload.snapshot
@@ -1,0 +1,3 @@
+Downloading 'bashunit' to '/tmp/test_bashdep_download_url_force_redownload'...
+mocked curl
+> bashunit installed successfully in '/tmp/test_bashdep_download_url_force_redownload'


### PR DESCRIPTION
Follow-up to #3. Aims for a grade-A+ developer experience without changing the small, focused scope of the library.

## API improvements

- **`bashdep::version`** — new function returning `BASHDEP_VERSION` (`0.2.0`).
- **`bashdep::setup` validation** — rejects unknown params and non-boolean values for `silent` / `force` with a stderr message and `rc=1`.
- **`bashdep::install` failure counting** — returns the number of failed downloads instead of silently swallowing errors. Pair with `|| exit $?` to fail fast.
- **`bashdep::setup_directory`** — returns `1` on `mkdir` failure rather than calling `exit` (safer for library use).
- **`bashdep::download_url`** — validates a non-empty URL argument; switched to `curl -fsSL` so HTTP errors (404, 5xx) become installation failures instead of writing error pages to disk.

## Docs

- Full README rewrite: status badges, TOC, "Why bashdep?", install snippet, full API table, behavior section (skip vs. force, dev deps, error handling), development section.
- Fix `.github/CONTRIBUTING.md` outdated `bashdep.sh` entry-point reference.

## Tooling

- Pin `bashunit` version in `install-dependencies.sh` to match CI (`0.17.0`); overridable via `BASHUNIT_VERSION`.
- `example/demo.sh`: drop redundant default args, propagate failures via `|| exit $?`.

## Tests

Six new tests:

- `force=true` re-downloads even when file exists
- `setup` rejects invalid bool (`silent=maybe`)
- `setup` rejects unknown param
- `download_url` rejects empty URL
- `install` returns the count of failures
- `version` is non-empty

Existing 6 tests still pass on both bashunit `0.17.0` (CI) and `0.21.0` (local).

## Test plan
- [x] `make test` — 12/12 pass on bashunit 0.21.0
- [x] `make test` — 12/12 pass on bashunit 0.17.0
- [x] `make sa` — ShellCheck clean
- [x] `make lint` — editorconfig-checker clean
- [ ] CI green on PR