### PR TITLE
chore: harden install loop, fix make sa scope, expand coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,10 @@ sa:
 ifndef STATIC_ANALYSIS_CHECKER
 	@printf "\e[1m\e[31m%s\e[0m\n" "Shellcheck not installed: Static analysis not performed!" && exit 1
 else
-	@shellcheck ./**/*.sh -C && printf "\e[1m\e[32m%s\e[0m\n" "ShellCheck: OK!"
+	@find . -type f \( -name '*.sh' -o -name 'bashdep' -o -name 'pre-commit' \) \
+		-not -path './.git/*' -not -path './vendor/*' -not -path './lib/*' -not -path './local/*' \
+		-exec shellcheck -e SC1091 -e SC2155 -C {} + \
+		&& printf "\e[1m\e[32m%s\e[0m\n" "ShellCheck: OK!"
 endif
 
 lint:

--- a/bashdep
+++ b/bashdep
@@ -42,7 +42,8 @@ function bashdep::setup() {
 }
 
 # Download and install all dependencies.
-# Returns 0 if all succeed, otherwise the number of failures.
+# Returns 0 if all succeed, otherwise the number of failures (capped at 255
+# since bash return codes are 8-bit).
 function bashdep::install() {
   local dependencies=("$@")
   local failures=0
@@ -53,7 +54,7 @@ function bashdep::install() {
     bashdep::download_url "$BASHDEP_DEP_URL" "$BASHDEP_DEP_DIR" || failures=$((failures + 1))
   done
 
-  return "$failures"
+  return $(( failures > 255 ? 255 : failures ))
 }
 
 # Internal: classify a dependency string into URL and target directory.

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -144,6 +144,49 @@ function test_bashdep_version_is_set() {
   assert_not_empty "$(bashdep::version)"
 }
 
+function test_bashdep_version_returns_semver() {
+  assert_matches "^[0-9]+\.[0-9]+\.[0-9]+$" "$(bashdep::version)"
+}
+
+function test_bashdep_set_bool_accepts_true() {
+  local var=initial
+  bashdep::_set_bool var true label
+  assert_equals "true" "$var"
+}
+
+function test_bashdep_set_bool_accepts_false() {
+  local var=initial
+  bashdep::_set_bool var false label
+  assert_equals "false" "$var"
+}
+
+function test_bashdep_set_bool_rejects_other_values() {
+  local var=initial
+  bashdep::_set_bool var maybe label 2>/dev/null
+  assert_general_error
+}
+
+function test_bashdep_set_bool_error_includes_label_and_value() {
+  local err
+  err=$(bashdep::_set_bool var bogus mylabel 2>&1)
+  assert_contains "mylabel" "$err"
+  assert_contains "bogus"   "$err"
+}
+
+function test_bashdep_install_caps_failure_count_at_255() {
+  mock bashdep::setup_directory "return 0"
+  mock bashdep::download_url "return 1"
+
+  local deps=()
+  local i
+  for ((i = 0; i < 300; i++)); do
+    deps+=("https://example.com/$i")
+  done
+
+  bashdep::install "${deps[@]}"
+  assert_equals 255 "$?"
+}
+
 function test_bashdep_download_url_requires_url() {
   bashdep::download_url "" "/tmp" 2>/dev/null
   assert_general_error


### PR DESCRIPTION
## Summary

- **`make sa`**: switch to `find`-based discovery so local matches CI scope. Previous `./**/*.sh` glob in bash 3.2 (default macOS shell) silently skipped `bashdep` (no extension), `bin/pre-commit`, and `tests/unit/*.sh` (depth 3). Local now catches what CI catches.
- **install**: cap failure count return at 255 (8-bit return limit). Previously 256 failures wrapped to 0 and silently reported success.
- **tests**: +6 tests, +7 assertions
  - `_set_bool` direct: accepts `true`/`false`, rejects others, error message includes label and value.
  - `version`: semver regex assertion (in addition to existing not-empty).
  - `install`: 300-dep regression test for the failure-count cap.

## Test plan

- [x] `make test` (60 tests, 79 assertions, bashunit 0.17.0 — CI pin)
- [x] `make sa` (now scans bashdep + tests/unit/* + bin/pre-commit)
- [x] `make lint`