### PR TITLE
feat: bashdep::list prints installed dependencies from lockfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 ### Added
 
 - `<dest>/.bashdep.lock` records the source URL of each installed dependency.
-- Internal helpers `bashdep::_lock_get` / `bashdep::_lock_set`.
+- Internal helpers `bashdep::_lock_get` / `bashdep::_lock_set` /
+  `bashdep::_classify_dep` / `bashdep::_should_skip_download` / `bashdep::_log`.
 - `bashdep::setup` with `dir`, `dev-dir`, `silent`, `force` parameters.
+- `bashdep::list` prints every installed dependency from the lockfiles
+  under `dir` and `dev-dir` (tab-separated `<path>\t<URL>` lines).
 - `@dev` URL suffix routes a dependency to `dev-dir`.
 - `bashdep::version` prints the current version.
 
@@ -20,7 +23,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - Pre-existing files without a lock entry are re-downloaded once on first
   run after upgrade to populate the lockfile.
 - Strict error handling: `download_url` / `setup_directory` return non-zero
-  on failure; `install` returns the failure count.
+  on failure; `install` returns the failure count (capped at 255).
+- `download_url` surfaces the `curl` exit code in its error message.
 - `BASHDEP_VERSION` set to `0.3.0` (in-tree; not yet released).
 
 ## [0.1]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ from your scripts.
 - [API](#api)
   - [`bashdep::install`](#bashdepinstall)
   - [`bashdep::setup`](#bashdepsetup)
+  - [`bashdep::list`](#bashdeplist)
   - [`bashdep::version`](#bashdepversion)
 - [Behavior](#behavior)
   - [Skip vs. force re-download](#skip-vs-force-re-download)
@@ -107,6 +108,19 @@ bashdep::setup dir="vendor" dev-dir="src/dev" silent=true force=false
 
 Invalid values (unknown param, non-boolean for `silent`/`force`) cause
 `setup` to print an error to stderr and return `1`.
+
+### `bashdep::list`
+
+Print every dependency recorded in the lockfiles under `dir` and `dev-dir`.
+One entry per line, tab-separated: `<path>\t<source URL>`. Pass extra
+directories as positional arguments to include their lockfiles too.
+
+```bash
+bashdep::list
+# lib/bashunit	https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
+# lib/create-pr	https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
+# lib/dev/dumper.sh	https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh
+```
 
 ### `bashdep::version`
 

--- a/bashdep
+++ b/bashdep
@@ -41,6 +41,23 @@ function bashdep::setup() {
   done
 }
 
+# Print installed dependencies recorded in lockfiles under BASHDEP_DIR and
+# BASHDEP_DEV_DIR. One entry per line, tab-separated: <path>\t<source URL>.
+# Skips directories without a lockfile. Pass extra dirs as arguments.
+function bashdep::list() {
+  local dirs=("$BASHDEP_DIR" "$BASHDEP_DEV_DIR" "$@")
+  local seen=""
+  local dir lock_file
+  for dir in "${dirs[@]}"; do
+    [[ -z "$dir" ]] && continue
+    case ":$seen:" in *":$dir:"*) continue ;; esac
+    seen="$seen:$dir"
+    lock_file="$dir/$BASHDEP_LOCK_FILE"
+    [[ -f "$lock_file" ]] || continue
+    awk -F '\t' -v dir="$dir" 'NF >= 2 { printf "%s/%s\t%s\n", dir, $1, $2 }' "$lock_file"
+  done
+}
+
 # Download and install all dependencies.
 # Returns 0 if all succeed, otherwise the number of failures (capped at 255
 # since bash return codes are 8-bit).

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -521,6 +521,64 @@ function test_bashdep_install_lockfile_contains_all_deps() {
   assert_contains "bbb" "$lock"
 }
 
+function test_bashdep_list_empty_when_no_lockfiles() {
+  BASHDEP_DIR="$TEST_DIR/empty_main"
+  BASHDEP_DEV_DIR="$TEST_DIR/empty_dev"
+  mkdir -p "$BASHDEP_DIR" "$BASHDEP_DEV_DIR"
+  assert_empty "$(bashdep::list)"
+}
+
+function test_bashdep_list_returns_entries_from_main_dir() {
+  BASHDEP_DIR="$TEST_DIR/main"
+  BASHDEP_DEV_DIR="$TEST_DIR/dev"
+  mkdir -p "$BASHDEP_DIR"
+  printf 'aaa\thttps://example.com/aaa\nbbb\thttps://example.com/bbb\n' \
+    > "$BASHDEP_DIR/.bashdep.lock"
+
+  local output
+  output=$(bashdep::list)
+  assert_contains "$BASHDEP_DIR/aaa	https://example.com/aaa" "$output"
+  assert_contains "$BASHDEP_DIR/bbb	https://example.com/bbb" "$output"
+}
+
+function test_bashdep_list_combines_main_and_dev_lockfiles() {
+  BASHDEP_DIR="$TEST_DIR/main"
+  BASHDEP_DEV_DIR="$TEST_DIR/dev"
+  mkdir -p "$BASHDEP_DIR" "$BASHDEP_DEV_DIR"
+  printf 'runtime\thttps://example.com/runtime\n' > "$BASHDEP_DIR/.bashdep.lock"
+  printf 'devtool\thttps://example.com/devtool\n' > "$BASHDEP_DEV_DIR/.bashdep.lock"
+
+  local output
+  output=$(bashdep::list)
+  assert_contains "$BASHDEP_DIR/runtime"    "$output"
+  assert_contains "$BASHDEP_DEV_DIR/devtool" "$output"
+}
+
+function test_bashdep_list_deduplicates_when_dir_equals_dev_dir() {
+  BASHDEP_DIR="$TEST_DIR/shared"
+  BASHDEP_DEV_DIR="$TEST_DIR/shared"
+  mkdir -p "$BASHDEP_DIR"
+  printf 'tool\thttps://example.com/tool\n' > "$BASHDEP_DIR/.bashdep.lock"
+
+  local count
+  count=$(bashdep::list | wc -l | tr -d ' ')
+  assert_equals "1" "$count"
+}
+
+function test_bashdep_list_includes_extra_dirs_passed_as_args() {
+  BASHDEP_DIR="$TEST_DIR/main"
+  BASHDEP_DEV_DIR="$TEST_DIR/dev"
+  local extra="$TEST_DIR/extra"
+  mkdir -p "$BASHDEP_DIR" "$extra"
+  printf 'main\thttps://example.com/main\n'  > "$BASHDEP_DIR/.bashdep.lock"
+  printf 'extra\thttps://example.com/extra\n' > "$extra/.bashdep.lock"
+
+  local output
+  output=$(bashdep::list "$extra")
+  assert_contains "$BASHDEP_DIR/main"  "$output"
+  assert_contains "$extra/extra"        "$output"
+}
+
 function test_bashdep_install_dev_lockfile_separated_from_main() {
   local main_dir="$TEST_DIR/main"
   local dev_dir="$TEST_DIR/dev"


### PR DESCRIPTION
## Summary

New API: `bashdep::list` prints every installed dependency from the lockfiles under `\$BASHDEP_DIR` and `\$BASHDEP_DEV_DIR`. Output is one line per dep, tab-separated as `<path>\t<source URL>`. Skips directories without a lockfile and de-duplicates when `dir`/`dev-dir` overlap.

```bash
bashdep::list
# lib/bashunit	https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
# lib/create-pr	https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
# lib/dev/dumper.sh	https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh
```

Pass extra directories as positional args to include their lockfiles too.

## Use cases

- Quickly check what URLs are pinned without opening lockfiles by hand.
- Pipe into `cut` / `awk` for audit, diff, or migration tooling.
- Compose with shell pipelines (e.g., grep for outdated GitHub release tags).

## Test plan

- [x] `make test` (65 tests, 87 assertions, bashunit 0.17.0 — CI pin)
- [x] `make sa`
- [x] `make lint`
- 5 new tests cover: empty case, main-only, main+dev combined, dedup when dirs match, extra-dir args.