### PR TITLE
feat: bashdep::install_from reads deps from a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - `bashdep::setup` with `dir`, `dev-dir`, `silent`, `force` parameters.
 - `bashdep::list` prints every installed dependency from the lockfiles
   under `dir` and `dev-dir` (tab-separated `<path>\t<URL>` lines).
+- `bashdep::install_from <file>` reads a dependency list from disk; blank
+  lines and `#` comments are ignored.
 - `@dev` URL suffix routes a dependency to `dev-dir`.
 - `bashdep::version` prints the current version.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,28 +6,26 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Added
 
-- `<dest>/.bashdep.lock` records the source URL of each installed dependency.
-- Internal helpers `bashdep::_lock_get` / `bashdep::_lock_set` /
-  `bashdep::_classify_dep` / `bashdep::_should_skip_download` / `bashdep::_log`.
-- `bashdep::setup` with `dir`, `dev-dir`, `silent`, `force` parameters.
-- `bashdep::list` prints every installed dependency from the lockfiles
-  under `dir` and `dev-dir` (tab-separated `<path>\t<URL>` lines).
 - `bashdep::install_from <file>` reads a dependency list from disk; blank
   lines and `#` comments are ignored.
-- `@dev` URL suffix routes a dependency to `dev-dir`.
+- `bashdep::list` prints every installed dependency from the lockfiles
+  under `dir` and `dev-dir` (tab-separated `<path>\t<URL>` lines).
+- `bashdep::setup` accepts `dir`, `dev-dir`, `silent`, `force` parameters.
 - `bashdep::version` prints the current version.
+- `@dev` URL suffix routes a dependency to `dev-dir`.
+- Per-directory `.bashdep.lock` records the source URL of each installed
+  dependency.
 
 ### Changed
 
-- `bashdep::install` is now idempotent **per source URL**, not per filename.
+- `bashdep::install` is idempotent **per source URL**, not per filename.
   A release bump (e.g. `0.17.0` → `0.18.0`) re-downloads even when the
-  basename is unchanged.
-- Pre-existing files without a lock entry are re-downloaded once on first
-  run after upgrade to populate the lockfile.
-- Strict error handling: `download_url` / `setup_directory` return non-zero
-  on failure; `install` returns the failure count (capped at 255).
+  basename is unchanged. Pre-existing files without a lock entry are
+  re-downloaded once after upgrade to populate the lockfile.
+- `bashdep::install` returns the failure count, capped at 255.
 - `download_url` surfaces the `curl` exit code in its error message.
-- `BASHDEP_VERSION` set to `0.3.0` (in-tree; not yet released).
+- Strict error handling: `download_url` / `setup_directory` return
+  non-zero on failure.
 
 ## [0.1]
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ from your scripts.
 - [Quick start](#quick-start)
 - [API](#api)
   - [`bashdep::install`](#bashdepinstall)
+  - [`bashdep::install_from`](#bashdepinstall_from)
   - [`bashdep::setup`](#bashdepsetup)
   - [`bashdep::list`](#bashdeplist)
   - [`bashdep::version`](#bashdepversion)
@@ -88,8 +89,32 @@ Download every dependency in the list into the configured directories.
 bashdep::install "${DEPENDENCIES[@]}"
 ```
 
-Returns the number of failed downloads (0 on success). Pair with
-`set -e` or check `$?` to gate the rest of your script.
+Returns the number of failed downloads (0 on success, capped at 255).
+Pair with `set -e` or check `$?` to gate the rest of your script.
+
+### `bashdep::install_from`
+
+Read a dependency list from a file and install every entry. Blank lines
+and lines starting with `#` are ignored; leading/trailing whitespace per
+line is stripped.
+
+```bash
+bashdep::install_from .bashdep
+```
+
+Example `.bashdep`:
+
+```
+# Runtime
+https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
+https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
+
+# Dev tools
+https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh@dev
+```
+
+Returns `1` if the file argument is missing or unreadable; otherwise
+returns the same failure count as `bashdep::install`.
 
 ### `bashdep::setup`
 

--- a/README.md
+++ b/README.md
@@ -21,17 +21,24 @@ from your scripts.
   - [`bashdep::list`](#bashdeplist)
   - [`bashdep::version`](#bashdepversion)
 - [Behavior](#behavior)
-  - [Skip vs. force re-download](#skip-vs-force-re-download)
+  - [Lockfile and idempotency](#lockfile-and-idempotency)
   - [Dev dependencies](#dev-dependencies)
   - [Error handling](#error-handling)
 - [Development](#development)
 
 ## Why bashdep?
 
-Most bash projects vendor scripts by hand: `curl`, `chmod +x`, repeat. bashdep
-turns that into one declarative list with sensible defaults: idempotent
-installs, dev/prod separation via the `@dev` suffix, and a single `force` flag
-to force a refresh. No package registry, no lockfile, no runtime — just `curl`.
+Most bash projects vendor scripts by hand: `curl`, `chmod +x`, repeat.
+bashdep turns that into one declarative list with sensible defaults:
+
+- Idempotent installs via a per-directory `.bashdep.lock`. Bumping a
+  release URL re-downloads automatically; same URL is skipped.
+- Dev/prod separation via the `@dev` URL suffix (`lib/` vs `lib/dev/`).
+- One `force=true` flag for full refreshes.
+- Read deps from a file (`bashdep::install_from .bashdep`) or pass an
+  array directly.
+
+No package registry, no runtime — just `curl`.
 
 ## Install
 
@@ -47,22 +54,27 @@ Then `source lib/bashdep` from your install script.
 
 ## Quick start
 
+Declare your deps in a `.bashdep` file:
+
+```
+# .bashdep
+https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
+https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
+https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh@dev
+```
+
+Then in your install script:
+
 ```bash
 #!/bin/bash
 set -euo pipefail
 
 source lib/bashdep
-
-DEPENDENCIES=(
-  "https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit"
-  "https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr"
-  "https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh@dev"
-)
-
-bashdep::install "${DEPENDENCIES[@]}"
+bashdep::install_from .bashdep
 ```
 
-Run it, and bashdep prints:
+First run downloads everything and writes `.bashdep.lock` in each
+destination directory:
 
 ```
 Downloading 'bashunit' to 'lib'...
@@ -73,48 +85,46 @@ Downloading 'dumper.sh' to 'lib/dev'...
 > dumper.sh installed successfully in 'lib/dev'
 ```
 
-Re-run it and previously-installed files are skipped:
+Re-runs skip already-installed deps; bumping a URL version re-downloads
+the affected entry only:
 
 ```
 > bashunit already exists in 'lib', skipping.
+> create-pr already exists in 'lib', skipping.
+> dumper.sh already exists in 'lib/dev', skipping.
 ```
+
+Prefer an inline array? Pass it to `bashdep::install` directly — see
+[`bashdep::install`](#bashdepinstall).
 
 ## API
 
 ### `bashdep::install`
 
-Download every dependency in the list into the configured directories.
+Download each dependency in the list into the configured directories.
 
 ```bash
+DEPENDENCIES=(
+  "https://example.com/runtime.sh"
+  "https://example.com/dev-tool.sh@dev"
+)
 bashdep::install "${DEPENDENCIES[@]}"
 ```
 
 Returns the number of failed downloads (0 on success, capped at 255).
-Pair with `set -e` or check `$?` to gate the rest of your script.
 
 ### `bashdep::install_from`
 
-Read a dependency list from a file and install every entry. Blank lines
-and lines starting with `#` are ignored; leading/trailing whitespace per
-line is stripped.
+Read a dependency list from a file and install every entry. One URL per
+line; blank lines and `#` comments are ignored; leading/trailing
+whitespace is stripped.
 
 ```bash
 bashdep::install_from .bashdep
 ```
 
-Example `.bashdep`:
-
-```
-# Runtime
-https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
-https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
-
-# Dev tools
-https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh@dev
-```
-
-Returns `1` if the file argument is missing or unreadable; otherwise
-returns the same failure count as `bashdep::install`.
+Returns `1` if the file is missing or unreadable; otherwise propagates
+the failure count from `bashdep::install`.
 
 ### `bashdep::setup`
 
@@ -136,16 +146,18 @@ Invalid values (unknown param, non-boolean for `silent`/`force`) cause
 
 ### `bashdep::list`
 
-Print every dependency recorded in the lockfiles under `dir` and `dev-dir`.
-One entry per line, tab-separated: `<path>\t<source URL>`. Pass extra
-directories as positional arguments to include their lockfiles too.
+Print every installed dependency recorded in the lockfiles under `dir`
+and `dev-dir`. One entry per line, tab-separated: `<path>\t<source URL>`.
+Pass extra directories as positional arguments to include them too.
 
 ```bash
-bashdep::list
-# lib/bashunit	https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
-# lib/create-pr	https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
-# lib/dev/dumper.sh	https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh
+$ bashdep::list
+lib/bashunit	https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
+lib/create-pr	https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
+lib/dev/dumper.sh	https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh
 ```
+
+Pipe into `awk` / `cut` for audit and diff tooling.
 
 ### `bashdep::version`
 
@@ -157,11 +169,11 @@ bashdep::version  # 0.3.0
 
 ## Behavior
 
-### Skip vs. force re-download
+### Lockfile and idempotency
 
-`bashdep::install` is idempotent **per source URL**, not per filename. The
-first install writes a `.bashdep.lock` file in each destination directory
-recording every dependency's source URL:
+`bashdep::install` is idempotent **per source URL**, not per filename.
+Each destination directory gets a `.bashdep.lock` recording the URL of
+every dependency installed there:
 
 ```
 # lib/.bashdep.lock
@@ -169,40 +181,46 @@ bashunit	https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
 create-pr	https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
 ```
 
-On subsequent runs, a dependency is skipped only when the file is present
-**and** the lockfile records the same URL. Bumping a release in the URL
-(e.g. `0.17.0` → `0.18.0`) triggers a re-download even though the basename
-is unchanged.
+Skip rules on subsequent runs:
 
-Pass `force=true` to refresh regardless of the lockfile:
+| File present | Lock URL matches | `force` | Action      |
+| :----------: | :--------------: | :-----: | ----------- |
+|     yes      |       yes        |   no    | skip        |
+|     yes      |        no        |   no    | re-download |
+|      no      |        —         |    —    | re-download |
+|     yes      |       yes        |   yes   | re-download |
 
-```bash
-bashdep::setup force=true
-bashdep::install "${DEPENDENCIES[@]}"
-```
+Bumping a release in the URL (`0.17.0` → `0.18.0`) re-downloads the
+affected entry only; nothing else is touched.
 
-Commit `.bashdep.lock` alongside your install script so collaborators get the
-same versions you do.
+Commit `.bashdep.lock` alongside your install script so collaborators
+get the same versions you do.
 
 ### Dev dependencies
 
-A URL ending in `@dev` is treated as a development-only dependency and
-installed into `dev-dir` instead of `dir`:
+A URL ending in `@dev` routes to `dev-dir` instead of `dir`:
 
 ```bash
 DEPENDENCIES=(
-  "https://example.com/runtime.sh"          # → lib/
-  "https://example.com/dev-tool.sh@dev"     # → lib/dev/
+  "https://example.com/runtime.sh"        # → lib/
+  "https://example.com/dev-tool.sh@dev"   # → lib/dev/
 )
 ```
 
+Each directory keeps its own `.bashdep.lock`.
+
 ### Error handling
 
-- `download_url` returns `1` and prints to stderr on `curl` failure or missing URL.
-- `install` keeps going through the list and returns the number of failures.
-- `setup_directory` returns `1` if it cannot create the destination dir.
+- `bashdep::install` continues past failed downloads and returns the
+  failure count (capped at 255).
+- `bashdep::install_from` returns `1` if the file is missing or
+  unreadable.
+- `bashdep::setup` returns `1` on unknown params or non-boolean values
+  for `silent` / `force`.
+- `curl` failures print the exit code to stderr (e.g. `22` = HTTP error,
+  `6` = DNS, `7` = connect refused).
 
-Use `set -e` plus `bashdep::install ... || exit $?` to fail fast in scripts.
+Pair with `set -euo pipefail` and `|| exit $?` to fail fast.
 
 ## Development
 

--- a/bashdep
+++ b/bashdep
@@ -41,6 +41,36 @@ function bashdep::setup() {
   done
 }
 
+# Read a dependency list from a file and install all entries.
+# One URL per line; blank lines and lines starting with `#` are ignored.
+# Leading/trailing whitespace per line is stripped. Returns the failure
+# count (capped at 255), or 1 if the file argument is missing or unreadable.
+function bashdep::install_from() {
+  local file=$1
+  if [[ -z "$file" ]]; then
+    echo "Error: install_from requires a file path." >&2
+    return 1
+  fi
+  if [[ ! -f "$file" ]]; then
+    echo "Error: dependency file '$file' not found." >&2
+    return 1
+  fi
+
+  local deps=()
+  local line
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    deps+=("$line")
+  done < "$file"
+
+  if [[ ${#deps[@]} -eq 0 ]]; then
+    return 0
+  fi
+  bashdep::install "${deps[@]}"
+}
+
 # Print installed dependencies recorded in lockfiles under BASHDEP_DIR and
 # BASHDEP_DEV_DIR. One entry per line, tab-separated: <path>\t<source URL>.
 # Skips directories without a lockfile. Pass extra dirs as arguments.

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -521,6 +521,86 @@ function test_bashdep_install_lockfile_contains_all_deps() {
   assert_contains "bbb" "$lock"
 }
 
+function test_bashdep_install_from_requires_file_arg() {
+  bashdep::install_from "" 2>/dev/null
+  assert_general_error
+}
+
+function test_bashdep_install_from_errors_on_missing_file() {
+  bashdep::install_from "$TEST_DIR/does_not_exist" 2>/dev/null
+  assert_general_error
+}
+
+function test_bashdep_install_from_passes_each_url_to_install() {
+  local file="$TEST_DIR/.bashdep"
+  cat > "$file" <<'EOF'
+https://example.com/aaa
+https://example.com/bbb
+EOF
+  mock bashdep::install "echo install \"\$@\""
+
+  local output
+  output=$(bashdep::install_from "$file")
+  assert_contains "https://example.com/aaa" "$output"
+  assert_contains "https://example.com/bbb" "$output"
+}
+
+function test_bashdep_install_from_skips_comments_and_blanks() {
+  local file="$TEST_DIR/.bashdep"
+  cat > "$file" <<'EOF'
+# top comment
+
+https://example.com/aaa
+  # indented comment
+
+https://example.com/bbb
+EOF
+  mock bashdep::install "echo install \"\$@\""
+
+  local output
+  output=$(bashdep::install_from "$file")
+  assert_not_contains "comment" "$output"
+  assert_contains     "https://example.com/aaa" "$output"
+  assert_contains     "https://example.com/bbb" "$output"
+}
+
+function test_bashdep_install_from_strips_whitespace() {
+  local file="$TEST_DIR/.bashdep"
+  printf '  https://example.com/aaa  \n\thttps://example.com/bbb\t\n' > "$file"
+  # shellcheck disable=SC2016
+  mock bashdep::install 'for d in "$@"; do printf "[%s]\n" "$d"; done'
+
+  local output
+  output=$(bashdep::install_from "$file")
+  assert_contains "[https://example.com/aaa]" "$output"
+  assert_contains "[https://example.com/bbb]" "$output"
+}
+
+function test_bashdep_install_from_empty_file_returns_zero() {
+  local file="$TEST_DIR/.bashdep"
+  : > "$file"
+  mock bashdep::install "echo SHOULD_NOT_RUN"
+
+  local output
+  output=$(bashdep::install_from "$file")
+  bashdep::install_from "$file"
+  assert_successful_code "$?"
+  assert_not_contains "SHOULD_NOT_RUN" "$output"
+}
+
+function test_bashdep_install_from_propagates_failure_count() {
+  local file="$TEST_DIR/.bashdep"
+  cat > "$file" <<'EOF'
+https://example.com/a
+https://example.com/b
+EOF
+  mock bashdep::setup_directory "return 0"
+  mock bashdep::download_url "return 1"
+
+  bashdep::install_from "$file"
+  assert_equals 2 "$?"
+}
+
 function test_bashdep_list_empty_when_no_lockfiles() {
   BASHDEP_DIR="$TEST_DIR/empty_main"
   BASHDEP_DEV_DIR="$TEST_DIR/empty_dev"


### PR DESCRIPTION
## Summary

New API: `bashdep::install_from <path>` reads a dependency list from disk and installs every entry. Pairs with `bashdep::list` (PR #7) for a fully declarative deps workflow.

```bash
# .bashdep
# Comments allowed
https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh@dev
```

```bash
source lib/bashdep
bashdep::install_from .bashdep
```

## Behavior

- One URL per line. Blank lines and lines starting with `#` are ignored.
- Leading/trailing whitespace per line is stripped (so indented `#` comments and trailing spaces don't break parsing).
- Returns `1` if the file argument is missing or unreadable; otherwise propagates the `bashdep::install` failure count (capped at 255).
- Empty file → returns `0` without calling `install`.

## Test plan

- [x] `make test` (72 tests, 99 assertions)
- [x] `make sa`
- [x] `make lint`
- 7 new tests cover: missing arg, missing file, happy path, comment/blank filtering, whitespace strip, empty file no-op, failure-count propagation.