### PR TITLE
docs: refresh CONTRIBUTING + example demo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,111 +1,112 @@
 # Contributing
 
-## We have a Code of Conduct
+Thanks for considering a contribution. This guide covers project layout,
+how to run the suite, and the conventions we follow.
 
-Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
-By participating in this project you agree to abide by its terms.
+## Code of Conduct
 
-## Any contributions you make will be under the MIT License
+This project follows a [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
+By participating you agree to abide by its terms.
 
-When you submit code changes, your submissions are understood to be under the
-same [MIT](../LICENSE) that covers the project. By contributing to this
-project, you agree that your contributions will be licensed under its MIT.
+## License
 
-## Write bug reports with detail, background, and sample code
+Contributions are licensed under [MIT](../LICENSE).
 
-In your bug report, please provide the following:
+## Project layout
 
-* A quick summary and/or background
-* Steps to reproduce
-  * Be specific!
-  * Give sample code if you can.
-* What you expected would happen
-* What actually happens
-* Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
+```
+bashdep                     # Library entry point — sourced by consumers
+tests/unit/bashdep_test.sh  # Unit tests (bashunit)
+tests/unit/snapshots/       # Captured stdout for snapshot assertions
+example/demo.sh             # End-to-end demo
+.github/workflows/          # CI: tests, ShellCheck, editorconfig
+Makefile                    # test / sa / lint / deps / pre_commit/install
+```
 
-Please post code and output as text ([using proper markup](https://guides.github.com/features/mastering-markdown/)).
-Additional screenshots to help contextualize behavior are ok.
+The codebase is intentionally small and zero-runtime: only `curl`,
+`awk`, `mktemp`, and POSIX-ish utilities at runtime. Tests run on
+bash 3.2+ (default macOS) and bash 4+ (Linux CI).
 
-## Workflow for Pull Requests
+## Workflow for pull requests
 
-1. Fork/clone the repository.
-2. Create your branch from `main` if you plan to implement new functionality or change existing code significantly.
-3. Implement your change and add tests for it.
-4. Ensure the test suite passes.
-5. Ensure the code complies with our coding guidelines (see below).
-6. Send that pull request!
+1. Fork/clone, branch from `main`.
+2. Implement the change and add tests for it.
+3. Run `make pre_commit/run` (test + ShellCheck + editorconfig).
+4. Open the PR with a short summary and a test plan.
 
-Please make sure you have [set up your username and email address](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup) for
-use with Git. Strings such as `silly nick name <root@localhost>` looks bad in the commit history of a project.
+Set your git `user.name` / `user.email` so commit history stays clean:
+see [first-time setup](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup).
 
+## Bug reports
 
----
+Please include:
 
-## Development
-
-- Entry point: `bashdep` (sourced by consumers as a library).
+- Summary and what you expected.
+- Steps to reproduce (sample code beats prose).
+- Actual output, pasted as text.
+- Environment: OS, `bash --version`.
 
 ## Testing
 
-Install dependencies: `make deps` (or `./install-dependencies.sh`).
-
-Run tests:
+Install dev dependencies (bashunit, pinned to the CI version):
 
 ```bash
-# using make
-make test
+make deps
+```
 
-# using bashunit directly
+Run the suite:
+
+```bash
+make test
+# or directly:
 lib/bashunit tests
 ```
 
-## Coding Guidelines
+Conventions in `tests/unit/bashdep_test.sh`:
+
+- One test per behavior. Names describe the assertion (`test_bashdep_…`).
+- Pure-logic tests (no filesystem) sit at the top of the file.
+- Filesystem tests use `$TEST_DIR` (a `mktemp -d` set up in `set_up`,
+  cleaned in `tear_down`). Use the `_seed_lock` / `_seed_installed`
+  helpers to scaffold lockfile fixtures.
+- Snapshot tests keep hardcoded `/tmp/test_<name>` paths because the
+  snapshot embeds the path. Don't migrate those to `$TEST_DIR`.
+
+## Coding guidelines
 
 ### ShellCheck
 
-To contribute to this repository you must have [ShellCheck](https://github.com/koalaman/shellcheck) installed on your
-local machine or IDE, since it is the static code analyzer that is being used in continuous integration pipelines.
-
-Installation: https://github.com/koalaman/shellcheck#installing
-
-#### Example of usage
+Install: <https://github.com/koalaman/shellcheck#installing>
 
 ```bash
-# using make
 make sa
-
-# using ShellCheck itself
-shellcheck ./**/**/*.sh -C
 ```
+
+`make sa` discovers scripts via `find` and matches CI scope: `bashdep`,
+`bin/pre-commit`, and every `*.sh` outside `vendor/`, `lib/`, `local/`.
 
 ### editorconfig-checker
 
-To contribute to this repository, consider installing [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker)
-to check all project files regarding the `.editorconfig` to ensure we all fulfill the standard.
-
-Installation: https://github.com/editorconfig-checker/editorconfig-checker#installation
-
-To run it, use the following command:
+Install: <https://github.com/editorconfig-checker/editorconfig-checker#installation>
 
 ```bash
-# using make
 make lint
-
-# using editorconfig-checker itself
-ec -config .editorconfig
 ```
 
-This command will be executed on the CI to ensure the project's quality standards.
+### Pre-commit hook (recommended)
 
-#### We recommend
-
-To install the pre-commit of the project with the following command:
-
-**Please note that you will need to have ShellCheck and editorconfig-checker installed on your computer.**
-See above how to install in your local.
+Requires ShellCheck and editorconfig-checker on `$PATH`.
 
 ```bash
 make pre_commit/install
 ```
 
-[Shell Guide](https://google.github.io/styleguide/shellguide.html#s7.2-variable-names) by Google Conventions.
+Runs `make pre_commit/run` (test + sa + lint) on every commit.
+
+### Style
+
+We follow Google's
+[Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
+where it doesn't conflict with this repo's conventions:
+`function name() { … }`, snake_case, and the `bashdep::` namespace
+prefix on every public function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Added
 
+- Dedicated `docs/` folder split out of README: `docs/api.md` (full API
+  reference) and `docs/behavior.md` (lockfile, dev deps, error handling).
 - `bashdep::install_from <file>` reads a dependency list from disk; blank
   lines and `#` comments are ignored.
 - `bashdep::list` prints every installed dependency from the lockfiles

--- a/README.md
+++ b/README.md
@@ -5,44 +5,9 @@
 [![Lint](https://github.com/Chemaclass/bashdep/actions/workflows/linter.yml/badge.svg)](https://github.com/Chemaclass/bashdep/actions/workflows/linter.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A minimalistic, zero-dependency **bash dependency manager**. Declare a list of
-URLs and bashdep will download them into a `lib/` directory you can `source`
-from your scripts.
-
-## Contents
-
-- [Why bashdep?](#why-bashdep)
-- [Install](#install)
-- [Quick start](#quick-start)
-- [API](#api)
-  - [`bashdep::install`](#bashdepinstall)
-  - [`bashdep::install_from`](#bashdepinstall_from)
-  - [`bashdep::setup`](#bashdepsetup)
-  - [`bashdep::list`](#bashdeplist)
-  - [`bashdep::version`](#bashdepversion)
-- [Behavior](#behavior)
-  - [Lockfile and idempotency](#lockfile-and-idempotency)
-  - [Dev dependencies](#dev-dependencies)
-  - [Error handling](#error-handling)
-- [Development](#development)
-
-## Why bashdep?
-
-Most bash projects vendor scripts by hand: `curl`, `chmod +x`, repeat.
-bashdep turns that into one declarative list with sensible defaults:
-
-- Idempotent installs via a per-directory `.bashdep.lock`. Bumping a
-  release URL re-downloads automatically; same URL is skipped.
-- Dev/prod separation via the `@dev` URL suffix (`lib/` vs `lib/dev/`).
-- One `force=true` flag for full refreshes.
-- Read deps from a file (`bashdep::install_from .bashdep`) or pass an
-  array directly.
-
-No package registry, no runtime — just `curl`.
-
-## Install
-
-Drop the `bashdep` script into your repo (typically under `lib/`):
+Minimal, zero-dependency **bash dependency manager**. Declare URLs;
+bashdep downloads them into `lib/` and keeps installs idempotent via a
+per-directory `.bashdep.lock`. No registry, no runtime — just `curl`.
 
 ```bash
 mkdir -p lib
@@ -50,20 +15,17 @@ curl -fsSLo lib/bashdep https://raw.githubusercontent.com/Chemaclass/bashdep/mai
 chmod +x lib/bashdep
 ```
 
-Then `source lib/bashdep` from your install script.
-
 ## Quick start
 
-Declare your deps in a `.bashdep` file:
+`.bashdep`:
 
 ```
-# .bashdep
 https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
 https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
 https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh@dev
 ```
 
-Then in your install script:
+`install-dependencies.sh`:
 
 ```bash
 #!/bin/bash
@@ -73,170 +35,37 @@ source lib/bashdep
 bashdep::install_from .bashdep
 ```
 
-First run downloads everything and writes `.bashdep.lock` in each
-destination directory:
+First run downloads everything and writes `.bashdep.lock`. Re-runs skip
+already-installed deps; bumping a URL version re-downloads only that
+entry. Commit `.bashdep.lock` to lock versions across collaborators.
 
-```
-Downloading 'bashunit' to 'lib'...
-> bashunit installed successfully in 'lib'
-Downloading 'create-pr' to 'lib'...
-> create-pr installed successfully in 'lib'
-Downloading 'dumper.sh' to 'lib/dev'...
-> dumper.sh installed successfully in 'lib/dev'
-```
+Prefer an inline array? Pass it to `bashdep::install` directly.
 
-Re-runs skip already-installed deps; bumping a URL version re-downloads
-the affected entry only:
+## Why bashdep?
 
-```
-> bashunit already exists in 'lib', skipping.
-> create-pr already exists in 'lib', skipping.
-> dumper.sh already exists in 'lib/dev', skipping.
-```
+- **Idempotent installs** via per-directory `.bashdep.lock`.
+- **Dev/prod separation** via the `@dev` URL suffix (`lib/` vs `lib/dev/`).
+- **Force refresh** with one flag (`force=true`).
+- **File-driven or array-driven** — `install_from` or `install`.
+- **List installed** deps in one command (`bashdep::list`).
 
-Prefer an inline array? Pass it to `bashdep::install` directly — see
-[`bashdep::install`](#bashdepinstall).
+## Documentation
 
-## API
-
-### `bashdep::install`
-
-Download each dependency in the list into the configured directories.
-
-```bash
-DEPENDENCIES=(
-  "https://example.com/runtime.sh"
-  "https://example.com/dev-tool.sh@dev"
-)
-bashdep::install "${DEPENDENCIES[@]}"
-```
-
-Returns the number of failed downloads (0 on success, capped at 255).
-
-### `bashdep::install_from`
-
-Read a dependency list from a file and install every entry. One URL per
-line; blank lines and `#` comments are ignored; leading/trailing
-whitespace is stripped.
-
-```bash
-bashdep::install_from .bashdep
-```
-
-Returns `1` if the file is missing or unreadable; otherwise propagates
-the failure count from `bashdep::install`.
-
-### `bashdep::setup`
-
-Configure defaults before calling `install`. All parameters are optional.
-
-| Param     | Type   | Default   | Purpose                                                |
-| --------- | ------ | --------- | ------------------------------------------------------ |
-| `dir`     | string | `lib`     | Destination for normal dependencies.                   |
-| `dev-dir` | string | `lib/dev` | Destination for dev dependencies (URLs ending `@dev`). |
-| `silent`  | bool   | `false`   | Suppress progress output.                              |
-| `force`   | bool   | `false`   | Re-download even when the file already exists.         |
-
-```bash
-bashdep::setup dir="vendor" dev-dir="src/dev" silent=true force=false
-```
-
-Invalid values (unknown param, non-boolean for `silent`/`force`) cause
-`setup` to print an error to stderr and return `1`.
-
-### `bashdep::list`
-
-Print every installed dependency recorded in the lockfiles under `dir`
-and `dev-dir`. One entry per line, tab-separated: `<path>\t<source URL>`.
-Pass extra directories as positional arguments to include them too.
-
-```bash
-$ bashdep::list
-lib/bashunit	https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
-lib/create-pr	https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
-lib/dev/dumper.sh	https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh
-```
-
-Pipe into `awk` / `cut` for audit and diff tooling.
-
-### `bashdep::version`
-
-Print the bashdep version.
-
-```bash
-bashdep::version  # 0.3.0
-```
-
-## Behavior
-
-### Lockfile and idempotency
-
-`bashdep::install` is idempotent **per source URL**, not per filename.
-Each destination directory gets a `.bashdep.lock` recording the URL of
-every dependency installed there:
-
-```
-# lib/.bashdep.lock
-bashunit	https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
-create-pr	https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
-```
-
-Skip rules on subsequent runs:
-
-| File present | Lock URL matches | `force` | Action      |
-| :----------: | :--------------: | :-----: | ----------- |
-|     yes      |       yes        |   no    | skip        |
-|     yes      |        no        |   no    | re-download |
-|      no      |        —         |    —    | re-download |
-|     yes      |       yes        |   yes   | re-download |
-
-Bumping a release in the URL (`0.17.0` → `0.18.0`) re-downloads the
-affected entry only; nothing else is touched.
-
-Commit `.bashdep.lock` alongside your install script so collaborators
-get the same versions you do.
-
-### Dev dependencies
-
-A URL ending in `@dev` routes to `dev-dir` instead of `dir`:
-
-```bash
-DEPENDENCIES=(
-  "https://example.com/runtime.sh"        # → lib/
-  "https://example.com/dev-tool.sh@dev"   # → lib/dev/
-)
-```
-
-Each directory keeps its own `.bashdep.lock`.
-
-### Error handling
-
-- `bashdep::install` continues past failed downloads and returns the
-  failure count (capped at 255).
-- `bashdep::install_from` returns `1` if the file is missing or
-  unreadable.
-- `bashdep::setup` returns `1` on unknown params or non-boolean values
-  for `silent` / `force`.
-- `curl` failures print the exit code to stderr (e.g. `22` = HTTP error,
-  `6` = DNS, `7` = connect refused).
-
-Pair with `set -euo pipefail` and `|| exit $?` to fail fast.
+- [**API reference**](docs/api.md) — `install`, `install_from`, `setup`,
+  `list`, `version`.
+- [**Behavior**](docs/behavior.md) — lockfile rules, dev dependencies,
+  error handling.
+- [**Contributing**](.github/CONTRIBUTING.md) — project layout, test
+  conventions, coding guidelines.
 
 ## Development
 
-Install test dependencies (bashunit) and run the suite:
-
 ```bash
-make deps
-make test
-```
-
-Other targets:
-
-```bash
-make sa                # ShellCheck static analysis
+make deps              # Install bashunit (test runner)
+make test              # Run the suite
+make sa                # ShellCheck
 make lint              # editorconfig-checker
 make pre_commit/install
 ```
 
-See [CONTRIBUTING](.github/CONTRIBUTING.md) for the full contributor guide.
+See [CONTRIBUTING](.github/CONTRIBUTING.md) for the full guide.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Documentation
+
+- [API reference](api.md) — every public `bashdep::*` function.
+- [Behavior](behavior.md) — lockfile rules, dev dependencies, error
+  handling.
+
+For contribution workflow and project layout, see
+[`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md).

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,88 @@
+# API reference
+
+Public functions exposed by `source lib/bashdep`.
+
+- [`bashdep::install`](#bashdepinstall)
+- [`bashdep::install_from`](#bashdepinstall_from)
+- [`bashdep::setup`](#bashdepsetup)
+- [`bashdep::list`](#bashdeplist)
+- [`bashdep::version`](#bashdepversion)
+
+## `bashdep::install`
+
+Download each dependency in the list into the configured directories.
+
+```bash
+DEPENDENCIES=(
+  "https://example.com/runtime.sh"
+  "https://example.com/dev-tool.sh@dev"
+)
+bashdep::install "${DEPENDENCIES[@]}"
+```
+
+Returns the number of failed downloads (0 on success, capped at 255).
+
+## `bashdep::install_from`
+
+Read a dependency list from a file and install every entry. One URL per
+line; blank lines and `#` comments are ignored; leading/trailing
+whitespace is stripped.
+
+```bash
+bashdep::install_from .bashdep
+```
+
+Example `.bashdep`:
+
+```
+# Runtime
+https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
+https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
+
+# Dev tools
+https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh@dev
+```
+
+Returns `1` if the file is missing or unreadable; otherwise propagates
+the failure count from `bashdep::install`.
+
+## `bashdep::setup`
+
+Configure defaults before calling `install`. All parameters are optional.
+
+| Param     | Type   | Default   | Purpose                                                |
+| --------- | ------ | --------- | ------------------------------------------------------ |
+| `dir`     | string | `lib`     | Destination for normal dependencies.                   |
+| `dev-dir` | string | `lib/dev` | Destination for dev dependencies (URLs ending `@dev`). |
+| `silent`  | bool   | `false`   | Suppress progress output.                              |
+| `force`   | bool   | `false`   | Re-download even when the file already exists.         |
+
+```bash
+bashdep::setup dir="vendor" dev-dir="src/dev" silent=true force=false
+```
+
+Invalid values (unknown param, non-boolean for `silent`/`force`) cause
+`setup` to print an error to stderr and return `1`.
+
+## `bashdep::list`
+
+Print every installed dependency recorded in the lockfiles under `dir`
+and `dev-dir`. One entry per line, tab-separated: `<path>\t<source URL>`.
+Pass extra directories as positional arguments to include them too.
+
+```bash
+$ bashdep::list
+lib/bashunit	https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
+lib/create-pr	https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
+lib/dev/dumper.sh	https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh
+```
+
+Pipe into `awk` / `cut` for audit and diff tooling.
+
+## `bashdep::version`
+
+Print the bashdep version.
+
+```bash
+bashdep::version  # 0.3.0
+```

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -1,0 +1,73 @@
+# Behavior
+
+How bashdep decides what to download, where to put it, and when to skip.
+
+- [Lockfile and idempotency](#lockfile-and-idempotency)
+- [Dev dependencies](#dev-dependencies)
+- [Error handling](#error-handling)
+
+## Lockfile and idempotency
+
+`bashdep::install` is idempotent **per source URL**, not per filename.
+Each destination directory gets a `.bashdep.lock` recording the URL of
+every dependency installed there:
+
+```
+# lib/.bashdep.lock
+bashunit	https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
+create-pr	https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
+```
+
+### Skip rules
+
+| File present | Lock URL matches | `force` | Action      |
+| :----------: | :--------------: | :-----: | ----------- |
+|     yes      |       yes        |   no    | skip        |
+|     yes      |        no        |   no    | re-download |
+|      no      |        —         |    —    | re-download |
+|     yes      |       yes        |   yes   | re-download |
+
+Bumping a release in the URL (`0.17.0` → `0.18.0`) re-downloads the
+affected entry only; nothing else is touched.
+
+### Recommended workflow
+
+Commit `.bashdep.lock` alongside your install script so collaborators
+get the same versions you do. Rotate by editing the URL in your
+dependency list (or `.bashdep` file) and re-running install — the
+lockfile updates automatically.
+
+## Dev dependencies
+
+A URL ending in `@dev` routes to `dev-dir` instead of `dir`:
+
+```bash
+DEPENDENCIES=(
+  "https://example.com/runtime.sh"        # → lib/
+  "https://example.com/dev-tool.sh@dev"   # → lib/dev/
+)
+```
+
+Each directory keeps its own `.bashdep.lock`. `bashdep::list` reads
+both by default.
+
+## Error handling
+
+- `bashdep::install` continues past failed downloads and returns the
+  failure count (capped at 255).
+- `bashdep::install_from` returns `1` if the file is missing or
+  unreadable.
+- `bashdep::setup` returns `1` on unknown params or non-boolean values
+  for `silent` / `force`.
+- `curl` failures print the exit code to stderr (e.g. `22` = HTTP error,
+  `6` = DNS, `7` = connect refused).
+
+Pair with `set -euo pipefail` and `|| exit $?` to fail fast:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+source lib/bashdep
+bashdep::install_from .bashdep || exit $?
+```

--- a/example/demo.sh
+++ b/example/demo.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+#
+# End-to-end demo of bashdep:
+#   - Inline DEPENDENCIES array passed to bashdep::install.
+#   - Custom destination directories via bashdep::setup.
+#   - Re-runs are idempotent thanks to the per-directory .bashdep.lock.
+#
+# Run from the repo root:  bash example/demo.sh
+#
+# To list what was installed afterwards:
+#   source bashdep && bashdep::setup dir=vendor dev-dir=local/dev && bashdep::list
+#
+# For the file-driven workflow, use bashdep::install_from <path> instead.
+
+set -euo pipefail
 
 # shellcheck disable=SC1091
 source "$(dirname "$0")/../bashdep"


### PR DESCRIPTION
## Summary

Brings the contributor guide and the runnable demo back in sync with the project as it stands after the lockfile / list / install_from rounds.

### CONTRIBUTING.md

- Add a **Project layout** section so new contributors can orient quickly (entry point, tests, snapshots, demo, CI, Makefile targets).
- Document the test conventions introduced in the recent isolation pass (`$TEST_DIR`, `_seed_lock` / `_seed_installed` helpers, when to keep hardcoded snapshot paths).
- Drop the stale `shellcheck ./**/**/*.sh -C` recommendation — that glob silently misses files in bash 3.2 (same pitfall the Makefile fix addressed). Point readers to `make sa` instead.
- Tighten the coding-guidelines section: one paragraph per tool, less prose padding.

### example/demo.sh

- Add a header comment explaining what the demo does and how to inspect the result via `bashdep::list`. Also pointers to the file-driven `install_from` workflow.

## Test plan

- [x] `make test` (72 tests, 99 assertions)
- [x] `make sa`
- [x] `make lint`
- Manually re-read CONTRIBUTING + demo to confirm no stale references to old API or test patterns.