### PR TITLE
feat: lifecycle utilities + dry-run/verbose modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Added
 
+- `bashdep::uninstall <file...>` removes a dep file plus its lockfile
+  entry; drops the lockfile when its last entry is gone.
+- `bashdep::clean` removes orphan files (in dir, not in lockfile).
+  Skips directories without a lockfile.
+- `bashdep::doctor` reports lockfile/filesystem inconsistencies
+  (missing files, orphan files). Returns the issue count.
+- `bashdep::self_update [ref] [target]` refreshes the bashdep script
+  from upstream via atomic `mv`. URL configurable via
+  `BASHDEP_SELF_URL_TEMPLATE`.
+- `dry-run=true` setup parameter previews actions without writing.
+- `verbose=true` setup parameter logs extra context (URLs on skip,
+  lockfile path on install). Suppressed by `silent=true`.
 - Dedicated `docs/` folder split out of README: `docs/api.md` (full API
   reference) and `docs/behavior.md` (lockfile, dev deps, error handling).
 - `bashdep::install_from <file>` reads a dependency list from disk; blank

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ Prefer an inline array? Pass it to `bashdep::install` directly.
 
 - **Idempotent installs** via per-directory `.bashdep.lock`.
 - **Dev/prod separation** via the `@dev` URL suffix (`lib/` vs `lib/dev/`).
-- **Force refresh** with one flag (`force=true`).
 - **File-driven or array-driven** — `install_from` or `install`.
-- **List installed** deps in one command (`bashdep::list`).
+- **Lifecycle commands** — `list`, `uninstall`, `clean`, `doctor`,
+  `self_update`.
+- **Modes** — `force`, `dry-run`, `silent`, `verbose`.
 
 ## Documentation
 

--- a/bashdep
+++ b/bashdep
@@ -110,6 +110,38 @@ function bashdep::uninstall() {
   return $(( missing > 255 ? 255 : missing ))
 }
 
+# Remove orphan files: anything in BASHDEP_DIR or BASHDEP_DEV_DIR that
+# isn't recorded in the local .bashdep.lock and isn't the lockfile itself.
+# Skips directories with no lockfile (a missing lockfile is treated as
+# 'don't manage this dir', not 'every file is an orphan').
+# In dry-run mode, prints intended removals without touching disk.
+# Returns 0 always; failures from individual rm calls are not propagated.
+function bashdep::clean() {
+  local removed=0
+  local dir lock_file file_path file_name seen=""
+  for dir in "$BASHDEP_DIR" "$BASHDEP_DEV_DIR"; do
+    [[ -z "$dir" || ! -d "$dir" ]] && continue
+    case ":$seen:" in *":$dir:"*) continue ;; esac
+    seen="$seen:$dir"
+    lock_file="$dir/$BASHDEP_LOCK_FILE"
+    [[ -f "$lock_file" ]] || continue
+    for file_path in "$dir"/*; do
+      [[ -f "$file_path" ]] || continue
+      file_name="${file_path##*/}"
+      [[ "$file_name" == "$BASHDEP_LOCK_FILE" ]] && continue
+      [[ -n "$(bashdep::_lock_get "$lock_file" "$file_name")" ]] && continue
+      if bashdep::is_dry_run; then
+        bashdep::_log "[dry-run] Would remove orphan '$file_path'"
+      else
+        rm -f "$file_path"
+        bashdep::_log "> removed orphan '$file_path'"
+      fi
+      removed=$((removed + 1))
+    done
+  done
+  bashdep::_log "Cleaned $removed orphan(s)."
+}
+
 # Print installed dependencies recorded in lockfiles under BASHDEP_DIR and
 # BASHDEP_DEV_DIR. One entry per line, tab-separated: <path>\t<source URL>.
 # Skips directories without a lockfile. Pass extra dirs as arguments.

--- a/bashdep
+++ b/bashdep
@@ -8,6 +8,7 @@ BASHDEP_LOCK_FILE=".bashdep.lock"
 BASHDEP_SILENT=false
 BASHDEP_FORCE=false
 BASHDEP_DRY_RUN=false
+BASHDEP_VERBOSE=false
 
 # Print bashdep version.
 function bashdep::version() {
@@ -25,6 +26,8 @@ function bashdep::version() {
 #   silent     - Suppress progress output (default: false).
 #   force      - Re-download dependencies even if they already exist (default: false).
 #   dry-run    - Preview actions without downloading or writing the lockfile (default: false).
+#   verbose    - Emit extra context (URLs on skip, lockfile path on write) (default: false).
+#                Suppressed by silent=true.
 #
 # Example:
 #   bashdep::setup dir="vendor" dev-dir="src/dev" silent=true
@@ -36,6 +39,7 @@ function bashdep::setup() {
       silent=*)    bashdep::_set_bool BASHDEP_SILENT  "${param#*=}" silent  || return 1 ;;
       force=*)     bashdep::_set_bool BASHDEP_FORCE   "${param#*=}" force   || return 1 ;;
       dry-run=*)   bashdep::_set_bool BASHDEP_DRY_RUN "${param#*=}" dry-run || return 1 ;;
+      verbose=*)   bashdep::_set_bool BASHDEP_VERBOSE "${param#*=}" verbose || return 1 ;;
       *)
         echo "Error: Invalid parameter '$param'" >&2
         return 1
@@ -159,6 +163,7 @@ function bashdep::download_url() {
 
   if bashdep::_should_skip_download "$destination_file" "$lock_file" "$file_name" "$url"; then
     bashdep::_log "> $file_name already exists in '$destination_dir', skipping."
+    bashdep::_vlog "  url: $url"
     return 0
   fi
 
@@ -168,6 +173,7 @@ function bashdep::download_url() {
   fi
 
   bashdep::_log "Downloading '$file_name' to '$destination_dir'..."
+  bashdep::_vlog "  url: $url"
 
   local rc
   curl -fsSL "$url" -o "$destination_file"
@@ -180,6 +186,7 @@ function bashdep::download_url() {
   bashdep::_log "> $file_name installed successfully in '$destination_dir'"
   chmod +x "$destination_file"
   bashdep::_lock_set "$lock_file" "$file_name" "$url" || return 1
+  bashdep::_vlog "  lockfile: $lock_file"
 }
 
 function bashdep::is_silent() {
@@ -194,9 +201,18 @@ function bashdep::is_dry_run() {
   [[ "$BASHDEP_DRY_RUN" == true ]]
 }
 
+function bashdep::is_verbose() {
+  [[ "$BASHDEP_VERBOSE" == true ]]
+}
+
 # Internal: print message to stdout unless silent mode is enabled.
 function bashdep::_log() {
   bashdep::is_silent || echo "$@"
+}
+
+# Internal: print only when verbose mode is on (and silent is off).
+function bashdep::_vlog() {
+  bashdep::is_verbose && bashdep::_log "$@"
 }
 
 # Internal: return 0 when an existing dependency can be reused.

--- a/bashdep
+++ b/bashdep
@@ -142,6 +142,49 @@ function bashdep::clean() {
   bashdep::_log "Cleaned $removed orphan(s)."
 }
 
+# Check each managed directory for consistency. Reports two kinds of issues:
+#   - Lockfile entries whose file is missing on disk.
+#   - Files on disk that have no lockfile entry (orphans).
+# Prints findings to stdout (suppressed by silent=true). Returns the issue
+# count, capped at 255. Returns 0 when everything is consistent.
+function bashdep::doctor() {
+  local issues=0
+  local dir lock_file file_path file_name entry_name entry_url seen=""
+  for dir in "$BASHDEP_DIR" "$BASHDEP_DEV_DIR"; do
+    [[ -z "$dir" || ! -d "$dir" ]] && continue
+    case ":$seen:" in *":$dir:"*) continue ;; esac
+    seen="$seen:$dir"
+    lock_file="$dir/$BASHDEP_LOCK_FILE"
+    if [[ ! -f "$lock_file" ]]; then
+      bashdep::_log "skip: '$dir' (no lockfile)"
+      continue
+    fi
+    bashdep::_log "checking '$dir'..."
+    while IFS=$'\t' read -r entry_name entry_url; do
+      [[ -z "$entry_name" ]] && continue
+      if [[ ! -f "$dir/$entry_name" ]]; then
+        bashdep::_log "  missing file for '$entry_name' (url: $entry_url)"
+        issues=$((issues + 1))
+      fi
+    done < "$lock_file"
+    for file_path in "$dir"/*; do
+      [[ -f "$file_path" ]] || continue
+      file_name="${file_path##*/}"
+      [[ "$file_name" == "$BASHDEP_LOCK_FILE" ]] && continue
+      if [[ -z "$(bashdep::_lock_get "$lock_file" "$file_name")" ]]; then
+        bashdep::_log "  orphan file '$file_path' (no lockfile entry)"
+        issues=$((issues + 1))
+      fi
+    done
+  done
+  if [[ $issues -eq 0 ]]; then
+    bashdep::_log "doctor: OK (no inconsistencies)"
+    return 0
+  fi
+  bashdep::_log "doctor: $issues issue(s) found"
+  return $(( issues > 255 ? 255 : issues ))
+}
+
 # Print installed dependencies recorded in lockfiles under BASHDEP_DIR and
 # BASHDEP_DEV_DIR. One entry per line, tab-separated: <path>\t<source URL>.
 # Skips directories without a lockfile. Pass extra dirs as arguments.

--- a/bashdep
+++ b/bashdep
@@ -7,6 +7,7 @@ BASHDEP_DEV_SUFFIX="@dev"
 BASHDEP_LOCK_FILE=".bashdep.lock"
 BASHDEP_SILENT=false
 BASHDEP_FORCE=false
+BASHDEP_DRY_RUN=false
 
 # Print bashdep version.
 function bashdep::version() {
@@ -16,13 +17,14 @@ function bashdep::version() {
 # Configure bashdep behavior.
 #
 # Usage:
-#   bashdep::setup [dir=DIR] [dev-dir=DEV_DIR] [silent=true|false] [force=true|false]
+#   bashdep::setup [dir=DIR] [dev-dir=DEV_DIR] [silent=BOOL] [force=BOOL] [dry-run=BOOL]
 #
 # Parameters:
 #       dir    - Default destination directory (default: lib).
 #   dev-dir    - Development destination directory (default: lib/dev).
 #   silent     - Suppress progress output (default: false).
 #   force      - Re-download dependencies even if they already exist (default: false).
+#   dry-run    - Preview actions without downloading or writing the lockfile (default: false).
 #
 # Example:
 #   bashdep::setup dir="vendor" dev-dir="src/dev" silent=true
@@ -31,8 +33,9 @@ function bashdep::setup() {
     case $param in
       dir=*)       BASHDEP_DIR="${param#*=}"        ;;
       dev-dir=*)   BASHDEP_DEV_DIR="${param#*=}"    ;;
-      silent=*)    bashdep::_set_bool BASHDEP_SILENT "${param#*=}" silent || return 1 ;;
-      force=*)     bashdep::_set_bool BASHDEP_FORCE "${param#*=}" force  || return 1 ;;
+      silent=*)    bashdep::_set_bool BASHDEP_SILENT  "${param#*=}" silent  || return 1 ;;
+      force=*)     bashdep::_set_bool BASHDEP_FORCE   "${param#*=}" force   || return 1 ;;
+      dry-run=*)   bashdep::_set_bool BASHDEP_DRY_RUN "${param#*=}" dry-run || return 1 ;;
       *)
         echo "Error: Invalid parameter '$param'" >&2
         return 1
@@ -159,6 +162,11 @@ function bashdep::download_url() {
     return 0
   fi
 
+  if bashdep::is_dry_run; then
+    bashdep::_log "[dry-run] Would download '$file_name' from '$url' to '$destination_dir'"
+    return 0
+  fi
+
   bashdep::_log "Downloading '$file_name' to '$destination_dir'..."
 
   local rc
@@ -180,6 +188,10 @@ function bashdep::is_silent() {
 
 function bashdep::is_force() {
   [[ "$BASHDEP_FORCE" == true ]]
+}
+
+function bashdep::is_dry_run() {
+  [[ "$BASHDEP_DRY_RUN" == true ]]
 }
 
 # Internal: print message to stdout unless silent mode is enabled.

--- a/bashdep
+++ b/bashdep
@@ -9,10 +9,56 @@ BASHDEP_SILENT=false
 BASHDEP_FORCE=false
 BASHDEP_DRY_RUN=false
 BASHDEP_VERBOSE=false
+BASHDEP_SELF_URL_TEMPLATE="${BASHDEP_SELF_URL_TEMPLATE:-https://raw.githubusercontent.com/Chemaclass/bashdep/%s/bashdep}"
 
 # Print bashdep version.
 function bashdep::version() {
   echo "$BASHDEP_VERSION"
+}
+
+# Re-download the bashdep script itself from the upstream repo.
+# Usage:
+#   bashdep::self_update [ref] [target_path]
+#
+# - ref         - Git ref (branch or tag). Default: main.
+# - target_path - Where to write. Default: the path this bashdep was
+#                 sourced from (BASH_SOURCE[0]).
+#
+# The download URL is built from BASHDEP_SELF_URL_TEMPLATE (a printf
+# format string with one %s slot for the ref). Honors dry-run mode.
+# Returns 1 on download or write failure.
+function bashdep::self_update() {
+  local ref=${1:-main}
+  local target=${2:-${BASH_SOURCE[0]}}
+  local url
+  # shellcheck disable=SC2059 # The template is intentionally user-controlled (env-overridable).
+  printf -v url "$BASHDEP_SELF_URL_TEMPLATE" "$ref"
+
+  if bashdep::is_dry_run; then
+    bashdep::_log "[dry-run] Would update '$target' from '$url'"
+    return 0
+  fi
+
+  local tmp
+  tmp=$(mktemp) || {
+    echo "Error: Could not create temp file for self_update." >&2
+    return 1
+  }
+
+  bashdep::_log "Updating '$target' from '$url'..."
+  if ! curl -fsSL "$url" -o "$tmp"; then
+    rm -f "$tmp"
+    echo "Error: failed to download bashdep from '$url'" >&2
+    return 1
+  fi
+
+  if ! mv "$tmp" "$target"; then
+    rm -f "$tmp"
+    echo "Error: failed to write '$target'" >&2
+    return 1
+  fi
+  chmod +x "$target"
+  bashdep::_log "> bashdep updated. Re-source the script to load the new version."
 }
 
 # Configure bashdep behavior.

--- a/bashdep
+++ b/bashdep
@@ -78,6 +78,38 @@ function bashdep::install_from() {
   bashdep::install "${deps[@]}"
 }
 
+# Remove one or more installed dependencies by file name. Searches
+# BASHDEP_DIR and BASHDEP_DEV_DIR; removes the file plus its lockfile
+# entry from wherever it lives. Drops empty lockfiles after the last
+# entry is removed. Returns the count of names not found (capped at 255).
+# In dry-run mode, prints the intended action without touching disk.
+function bashdep::uninstall() {
+  local missing=0
+  local file_name dir lock_file found
+  for file_name in "$@"; do
+    found=false
+    for dir in "$BASHDEP_DIR" "$BASHDEP_DEV_DIR"; do
+      [[ -z "$dir" ]] && continue
+      lock_file="$dir/$BASHDEP_LOCK_FILE"
+      if [[ -f "$dir/$file_name" ]] || [[ -n "$(bashdep::_lock_get "$lock_file" "$file_name")" ]]; then
+        found=true
+        if bashdep::is_dry_run; then
+          bashdep::_log "[dry-run] Would remove '$dir/$file_name' and its lockfile entry"
+        else
+          rm -f "$dir/$file_name"
+          bashdep::_lock_remove "$lock_file" "$file_name" || return 1
+          bashdep::_log "> $file_name removed from '$dir'"
+        fi
+      fi
+    done
+    if ! $found; then
+      echo "Error: '$file_name' not found in any configured directory." >&2
+      missing=$((missing + 1))
+    fi
+  done
+  return $(( missing > 255 ? 255 : missing ))
+}
+
 # Print installed dependencies recorded in lockfiles under BASHDEP_DIR and
 # BASHDEP_DEV_DIR. One entry per line, tab-separated: <path>\t<source URL>.
 # Skips directories without a lockfile. Pass extra dirs as arguments.
@@ -243,6 +275,30 @@ function bashdep::_lock_get() {
   local lock_file=$1 file_name=$2
   [[ -f "$lock_file" ]] || return 0
   awk -F '\t' -v name="$file_name" '$1 == name { print $2; exit }' "$lock_file"
+}
+
+# Internal: drop the entry for $file_name from the lockfile. Removes the
+# lockfile entirely once it has no entries left. No-op when the lockfile
+# does not exist. Returns 1 if the rewrite cannot be persisted.
+function bashdep::_lock_remove() {
+  local lock_file=$1 file_name=$2
+  [[ -f "$lock_file" ]] || return 0
+  local lock_dir tmp
+  lock_dir=$(dirname "$lock_file")
+  tmp=$(mktemp "$lock_dir/.bashdep.lock.XXXXXX") || {
+    echo "Error: Could not create temp file for lockfile update." >&2
+    return 1
+  }
+  awk -F '\t' -v name="$file_name" '$1 != name' "$lock_file" | LC_ALL=C sort > "$tmp"
+  if [[ ! -s "$tmp" ]]; then
+    rm -f "$tmp" "$lock_file"
+    return 0
+  fi
+  if ! mv "$tmp" "$lock_file"; then
+    rm -f "$tmp"
+    echo "Error: Could not write lockfile '$lock_file'." >&2
+    return 1
+  fi
 }
 
 # Internal: upsert filename → URL mapping in lockfile.

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,6 +4,10 @@ Public functions exposed by `source lib/bashdep`.
 
 - [`bashdep::install`](#bashdepinstall)
 - [`bashdep::install_from`](#bashdepinstall_from)
+- [`bashdep::uninstall`](#bashdepuninstall)
+- [`bashdep::clean`](#bashdepclean)
+- [`bashdep::doctor`](#bashdepdoctor)
+- [`bashdep::self_update`](#bashdepself_update)
 - [`bashdep::setup`](#bashdepsetup)
 - [`bashdep::list`](#bashdeplist)
 - [`bashdep::version`](#bashdepversion)
@@ -46,6 +50,65 @@ https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh@dev
 Returns `1` if the file is missing or unreadable; otherwise propagates
 the failure count from `bashdep::install`.
 
+## `bashdep::uninstall`
+
+Remove one or more installed dependencies. Searches `dir` and `dev-dir`,
+deletes the file, and drops the matching `.bashdep.lock` entry. The
+lockfile is removed once it has no entries left.
+
+```bash
+bashdep::uninstall create-pr dumper.sh
+```
+
+Returns the number of names not found (0 on full success). In dry-run
+mode, prints intended actions without touching disk.
+
+## `bashdep::clean`
+
+Remove orphan files in each managed directory: anything not recorded in
+`.bashdep.lock` (and not the lockfile itself). Directories without a
+lockfile are left alone — bashdep treats a missing lockfile as "this
+dir is unmanaged".
+
+```bash
+bashdep::clean
+```
+
+Always returns 0. Honors dry-run mode.
+
+## `bashdep::doctor`
+
+Check each managed directory for inconsistencies. Reports two kinds of
+issues:
+
+- Lockfile entries whose file is missing on disk.
+- Files on disk with no lockfile entry.
+
+```bash
+bashdep::doctor
+# checking 'lib'...
+#   missing file for 'create-pr' (url: https://...)
+#   orphan file 'lib/leftover.sh' (no lockfile entry)
+# doctor: 2 issue(s) found
+```
+
+Returns the issue count (capped at 255). Useful in CI to catch lockfile
+drift after manual edits or merge conflicts.
+
+## `bashdep::self_update`
+
+Re-download the bashdep script itself from upstream and replace the
+local copy via an atomic `mv`. Defaults to the `main` branch.
+
+```bash
+bashdep::self_update            # main branch
+bashdep::self_update 0.4.0      # specific tag/branch
+```
+
+The download URL is built from `BASHDEP_SELF_URL_TEMPLATE` (a printf
+format string with one `%s` slot for the ref). After updating, re-source
+the script to load the new version. Honors dry-run mode.
+
 ## `bashdep::setup`
 
 Configure defaults before calling `install`. All parameters are optional.
@@ -56,6 +119,8 @@ Configure defaults before calling `install`. All parameters are optional.
 | `dev-dir` | string | `lib/dev` | Destination for dev dependencies (URLs ending `@dev`). |
 | `silent`  | bool   | `false`   | Suppress progress output.                              |
 | `force`   | bool   | `false`   | Re-download even when the file already exists.         |
+| `dry-run` | bool   | `false`   | Preview actions without writing to disk.               |
+| `verbose` | bool   | `false`   | Emit extra context (URLs on skip, lockfile path).      |
 
 ```bash
 bashdep::setup dir="vendor" dev-dir="src/dev" silent=true force=false

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -8,6 +8,7 @@ function set_up() {
   source "$(current_dir)/../../bashdep"
   BASHDEP_FORCE=false
   BASHDEP_SILENT=false
+  BASHDEP_DRY_RUN=false
   TEST_DIR=$(mktemp -d)
 }
 
@@ -83,6 +84,51 @@ function test_bashdep_is_force_false_when_var_false() {
   BASHDEP_FORCE=false
   bashdep::is_force
   assert_general_error
+}
+
+function test_bashdep_is_dry_run_true_when_var_true() {
+  BASHDEP_DRY_RUN=true
+  bashdep::is_dry_run
+  assert_successful_code "$?"
+}
+
+function test_bashdep_is_dry_run_false_when_var_false() {
+  BASHDEP_DRY_RUN=false
+  bashdep::is_dry_run
+  assert_general_error
+}
+
+function test_bashdep_setup_dry_run_true_makes_is_dry_run_truthy() {
+  bashdep::setup dry-run=true
+  bashdep::is_dry_run
+  assert_successful_code "$?"
+}
+
+function test_bashdep_download_url_dry_run_skips_curl_and_lockfile() {
+  mock curl "echo SHOULD_NOT_RUN"
+  bashdep::setup dry-run=true
+
+  local output
+  output=$(bashdep::download_url "https://example.com/tool" "$TEST_DIR")
+
+  assert_not_contains "SHOULD_NOT_RUN" "$output"
+  assert_contains     "[dry-run]"      "$output"
+  assert_file_not_exists "$TEST_DIR/tool"
+  assert_file_not_exists "$TEST_DIR/.bashdep.lock"
+}
+
+function test_bashdep_download_url_dry_run_still_skips_when_lock_matches() {
+  local url="https://example.com/tool"
+  _seed_installed "$TEST_DIR" tool "$url"
+  mock curl "echo SHOULD_NOT_RUN"
+  bashdep::setup dry-run=true
+
+  local output
+  output=$(bashdep::download_url "$url" "$TEST_DIR")
+
+  assert_not_contains "SHOULD_NOT_RUN" "$output"
+  assert_not_contains "[dry-run]"       "$output"
+  assert_contains     "skipping"        "$output"
 }
 
 function test_bashdep_log_prints_when_not_silent() {

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -754,6 +754,60 @@ function test_bashdep_uninstall_dry_run_skips_actual_removal() {
   assert_file_exists "$TEST_DIR/.bashdep.lock"
 }
 
+function test_bashdep_clean_removes_orphan_files() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" tracked https://example.com/tracked
+  touch "$TEST_DIR/orphan"
+
+  bashdep::clean >/dev/null
+  assert_file_exists     "$TEST_DIR/tracked"
+  assert_file_not_exists "$TEST_DIR/orphan"
+}
+
+function test_bashdep_clean_preserves_lockfile_itself() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" tracked https://example.com/tracked
+  touch "$TEST_DIR/orphan"
+
+  bashdep::clean >/dev/null
+  assert_file_exists "$TEST_DIR/.bashdep.lock"
+}
+
+function test_bashdep_clean_skips_dir_without_lockfile() {
+  BASHDEP_DIR="$TEST_DIR"
+  touch "$TEST_DIR/keep_me"
+
+  bashdep::clean >/dev/null
+  assert_file_exists "$TEST_DIR/keep_me"
+}
+
+function test_bashdep_clean_dry_run_preserves_files() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" tracked https://example.com/tracked
+  touch "$TEST_DIR/orphan"
+  bashdep::setup dry-run=true
+
+  local output
+  output=$(bashdep::clean)
+  assert_contains    "[dry-run]"         "$output"
+  assert_file_exists "$TEST_DIR/orphan"
+}
+
+function test_bashdep_clean_handles_both_dirs() {
+  BASHDEP_DIR="$TEST_DIR/main"
+  BASHDEP_DEV_DIR="$TEST_DIR/dev"
+  mkdir -p "$BASHDEP_DIR" "$BASHDEP_DEV_DIR"
+  _seed_installed "$BASHDEP_DIR"     a https://example.com/a
+  _seed_installed "$BASHDEP_DEV_DIR" b https://example.com/b
+  touch "$BASHDEP_DIR/orphan_main" "$BASHDEP_DEV_DIR/orphan_dev"
+
+  bashdep::clean >/dev/null
+  assert_file_not_exists "$BASHDEP_DIR/orphan_main"
+  assert_file_not_exists "$BASHDEP_DEV_DIR/orphan_dev"
+  assert_file_exists     "$BASHDEP_DIR/a"
+  assert_file_exists     "$BASHDEP_DEV_DIR/b"
+}
+
 function test_bashdep_lock_remove_drops_entry() {
   local lock_file="$TEST_DIR/lock"
   printf 'aaa\thttps://example.com/aaa\nbbb\thttps://example.com/bbb\n' > "$lock_file"

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -697,6 +697,85 @@ EOF
   assert_equals 2 "$?"
 }
 
+function test_bashdep_uninstall_removes_file_and_lock_entry() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" tool https://example.com/tool
+
+  bashdep::uninstall tool >/dev/null
+  assert_file_not_exists "$TEST_DIR/tool"
+  assert_empty "$(bashdep::_lock_get "$TEST_DIR/.bashdep.lock" tool)"
+}
+
+function test_bashdep_uninstall_drops_lockfile_when_empty() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" tool https://example.com/tool
+
+  bashdep::uninstall tool >/dev/null
+  assert_file_not_exists "$TEST_DIR/.bashdep.lock"
+}
+
+function test_bashdep_uninstall_keeps_lockfile_with_remaining_entries() {
+  BASHDEP_DIR="$TEST_DIR"
+  touch "$TEST_DIR/aaa" "$TEST_DIR/bbb"
+  printf 'aaa\thttps://example.com/aaa\nbbb\thttps://example.com/bbb\n' > "$TEST_DIR/.bashdep.lock"
+
+  bashdep::uninstall aaa >/dev/null
+  assert_file_exists "$TEST_DIR/.bashdep.lock"
+  assert_equals "https://example.com/bbb" "$(bashdep::_lock_get "$TEST_DIR/.bashdep.lock" bbb)"
+  assert_empty  "$(bashdep::_lock_get "$TEST_DIR/.bashdep.lock" aaa)"
+}
+
+function test_bashdep_uninstall_searches_dev_dir() {
+  BASHDEP_DIR="$TEST_DIR/main"
+  BASHDEP_DEV_DIR="$TEST_DIR/dev"
+  mkdir -p "$BASHDEP_DIR" "$BASHDEP_DEV_DIR"
+  _seed_installed "$BASHDEP_DEV_DIR" tool https://example.com/tool
+
+  bashdep::uninstall tool >/dev/null
+  assert_successful_code "$?"
+  assert_file_not_exists "$BASHDEP_DEV_DIR/tool"
+}
+
+function test_bashdep_uninstall_returns_nonzero_when_not_found() {
+  BASHDEP_DIR="$TEST_DIR"
+  bashdep::uninstall ghost 2>/dev/null
+  assert_general_error
+}
+
+function test_bashdep_uninstall_dry_run_skips_actual_removal() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" tool https://example.com/tool
+  bashdep::setup dry-run=true
+
+  local output
+  output=$(bashdep::uninstall tool)
+  assert_contains  "[dry-run]" "$output"
+  assert_file_exists "$TEST_DIR/tool"
+  assert_file_exists "$TEST_DIR/.bashdep.lock"
+}
+
+function test_bashdep_lock_remove_drops_entry() {
+  local lock_file="$TEST_DIR/lock"
+  printf 'aaa\thttps://example.com/aaa\nbbb\thttps://example.com/bbb\n' > "$lock_file"
+
+  bashdep::_lock_remove "$lock_file" aaa
+  assert_empty "$(bashdep::_lock_get "$lock_file" aaa)"
+  assert_equals "https://example.com/bbb" "$(bashdep::_lock_get "$lock_file" bbb)"
+}
+
+function test_bashdep_lock_remove_deletes_empty_lockfile() {
+  local lock_file="$TEST_DIR/lock"
+  printf 'only\thttps://example.com/only\n' > "$lock_file"
+
+  bashdep::_lock_remove "$lock_file" only
+  assert_file_not_exists "$lock_file"
+}
+
+function test_bashdep_lock_remove_no_op_when_lockfile_missing() {
+  bashdep::_lock_remove "$TEST_DIR/nope" anything
+  assert_successful_code "$?"
+}
+
 function test_bashdep_list_empty_when_no_lockfiles() {
   BASHDEP_DIR="$TEST_DIR/empty_main"
   BASHDEP_DEV_DIR="$TEST_DIR/empty_dev"

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -9,6 +9,7 @@ function set_up() {
   BASHDEP_FORCE=false
   BASHDEP_SILENT=false
   BASHDEP_DRY_RUN=false
+  BASHDEP_VERBOSE=false
   TEST_DIR=$(mktemp -d)
 }
 
@@ -115,6 +116,55 @@ function test_bashdep_download_url_dry_run_skips_curl_and_lockfile() {
   assert_contains     "[dry-run]"      "$output"
   assert_file_not_exists "$TEST_DIR/tool"
   assert_file_not_exists "$TEST_DIR/.bashdep.lock"
+}
+
+function test_bashdep_is_verbose_true_when_var_true() {
+  BASHDEP_VERBOSE=true
+  bashdep::is_verbose
+  assert_successful_code "$?"
+}
+
+function test_bashdep_is_verbose_false_when_var_false() {
+  BASHDEP_VERBOSE=false
+  bashdep::is_verbose
+  assert_general_error
+}
+
+function test_bashdep_setup_verbose_true_makes_is_verbose_truthy() {
+  bashdep::setup verbose=true
+  bashdep::is_verbose
+  assert_successful_code "$?"
+}
+
+function test_bashdep_download_url_verbose_logs_url_on_skip() {
+  local url="https://example.com/tool"
+  _seed_installed "$TEST_DIR" tool "$url"
+  bashdep::setup verbose=true
+
+  local output
+  output=$(bashdep::download_url "$url" "$TEST_DIR")
+  assert_contains "skipping"     "$output"
+  assert_contains "url: $url"    "$output"
+}
+
+function test_bashdep_download_url_verbose_logs_lockfile_after_install() {
+  # shellcheck disable=SC2016
+  mock curl 'touch "$4"'
+  bashdep::setup verbose=true
+
+  local output
+  output=$(bashdep::download_url "https://example.com/tool" "$TEST_DIR")
+  assert_contains "lockfile: $TEST_DIR/.bashdep.lock" "$output"
+}
+
+function test_bashdep_download_url_silent_overrides_verbose() {
+  local url="https://example.com/tool"
+  _seed_installed "$TEST_DIR" tool "$url"
+  bashdep::setup verbose=true silent=true
+
+  local output
+  output=$(bashdep::download_url "$url" "$TEST_DIR")
+  assert_empty "$output"
 }
 
 function test_bashdep_download_url_dry_run_still_skips_when_lock_matches() {

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -754,6 +754,62 @@ function test_bashdep_uninstall_dry_run_skips_actual_removal() {
   assert_file_exists "$TEST_DIR/.bashdep.lock"
 }
 
+function test_bashdep_doctor_reports_orphan_files() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" tracked https://example.com/tracked
+  touch "$TEST_DIR/orphan"
+
+  local output
+  output=$(bashdep::doctor)
+  local rc=$?
+  assert_contains "orphan file" "$output"
+  assert_equals 1 "$rc"
+}
+
+function test_bashdep_doctor_reports_missing_files() {
+  BASHDEP_DIR="$TEST_DIR"
+  printf 'gone\thttps://example.com/gone\n' > "$TEST_DIR/.bashdep.lock"
+
+  local output
+  output=$(bashdep::doctor)
+  local rc=$?
+  assert_contains "missing file" "$output"
+  assert_equals 1 "$rc"
+}
+
+function test_bashdep_doctor_ok_when_consistent() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" tracked https://example.com/tracked
+
+  local output
+  output=$(bashdep::doctor)
+  assert_successful_code "$?"
+  assert_contains "OK" "$output"
+}
+
+function test_bashdep_doctor_skips_dir_without_lockfile() {
+  BASHDEP_DIR="$TEST_DIR"
+  touch "$TEST_DIR/free_file"
+
+  local output
+  output=$(bashdep::doctor)
+  assert_successful_code "$?"
+  assert_contains "skip" "$output"
+}
+
+function test_bashdep_doctor_counts_issues_across_dirs() {
+  BASHDEP_DIR="$TEST_DIR/main"
+  BASHDEP_DEV_DIR="$TEST_DIR/dev"
+  mkdir -p "$BASHDEP_DIR" "$BASHDEP_DEV_DIR"
+  _seed_installed "$BASHDEP_DIR"     a https://example.com/a
+  _seed_installed "$BASHDEP_DEV_DIR" b https://example.com/b
+  touch "$BASHDEP_DIR/orphan_main"
+  printf 'gone\thttps://example.com/gone\n' >> "$BASHDEP_DEV_DIR/.bashdep.lock"
+
+  bashdep::doctor >/dev/null
+  assert_equals 2 "$?"
+}
+
 function test_bashdep_clean_removes_orphan_files() {
   BASHDEP_DIR="$TEST_DIR"
   _seed_installed "$TEST_DIR" tracked https://example.com/tracked

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -754,6 +754,47 @@ function test_bashdep_uninstall_dry_run_skips_actual_removal() {
   assert_file_exists "$TEST_DIR/.bashdep.lock"
 }
 
+function test_bashdep_self_update_writes_target_from_curl() {
+  local target="$TEST_DIR/bashdep_copy"
+  # shellcheck disable=SC2016
+  mock curl 'printf "NEW_BASHDEP_CONTENT\n" > "$4"'
+
+  bashdep::self_update main "$target" >/dev/null
+  assert_file_exists "$target"
+  assert_contains "NEW_BASHDEP_CONTENT" "$(cat "$target")"
+}
+
+function test_bashdep_self_update_dry_run_skips_write() {
+  local target="$TEST_DIR/bashdep_copy"
+  mock curl "echo SHOULD_NOT_RUN"
+  bashdep::setup dry-run=true
+
+  local output
+  output=$(bashdep::self_update main "$target")
+  assert_contains       "[dry-run]" "$output"
+  assert_file_not_exists "$target"
+}
+
+function test_bashdep_self_update_curl_failure_returns_nonzero() {
+  local target="$TEST_DIR/bashdep_copy"
+  mock curl "return 22"
+
+  bashdep::self_update main "$target" 2>/dev/null >/dev/null
+  assert_general_error
+  assert_file_not_exists "$target"
+}
+
+function test_bashdep_self_update_uses_url_template() {
+  local target="$TEST_DIR/bashdep_copy"
+  BASHDEP_SELF_URL_TEMPLATE="https://example.test/bashdep/%s"
+  # download_url contract: curl -fsSL <url> -o <dest> -> $2=url, $4=dest.
+  # shellcheck disable=SC2016
+  mock curl 'printf "from=%s\n" "$2" > "$4"'
+
+  bashdep::self_update v1.2.3 "$target" >/dev/null
+  assert_contains "from=https://example.test/bashdep/v1.2.3" "$(cat "$target")"
+}
+
 function test_bashdep_doctor_reports_orphan_files() {
   BASHDEP_DIR="$TEST_DIR"
   _seed_installed "$TEST_DIR" tracked https://example.com/tracked


### PR DESCRIPTION
## Summary

Six new APIs / modes, one commit per idea. Each commit ships with tests
and ShellCheck-clean code.

| Commit | Adds                               | Why                                                                  |
| :----: | :--------------------------------- | :------------------------------------------------------------------- |
| 1      | `dry-run=true` mode                | Preview install/uninstall/clean/self_update without touching disk.   |
| 2      | `verbose=true` mode                | Surface URLs on skip and lockfile path on install for debugging.     |
| 3      | `bashdep::uninstall <file...>`     | Remove a dep file and its lockfile entry; drop empty lockfiles.      |
| 4      | `bashdep::clean`                   | Remove orphan files (in dir, not in lockfile).                       |
| 5      | `bashdep::doctor`                  | Report lockfile/filesystem inconsistencies; useful in CI gates.      |
| 6      | `bashdep::self_update [ref] [tgt]` | Refresh the bashdep script itself from upstream via atomic mv.       |
| 7      | docs + CHANGELOG                   | API reference, README selling points, changelog entries.             |

## Behavior notes

- **Dry-run** is honored by `download_url`, `uninstall`, `clean`, and `self_update`. Skip-path output is unchanged (skip writes nothing either way).
- **Verbose** is suppressed by `silent=true` (silent wins). Adds an extra `  url: $url` line on skip and `  lockfile: $path` after install.
- **`uninstall`** searches both `\$BASHDEP_DIR` and `\$BASHDEP_DEV_DIR`; deletes the matching file and entry; drops the lockfile once empty.
- **`clean`** treats a directory without a `.bashdep.lock` as unmanaged (no orphans removed) — won't nuke unrelated files.
- **`doctor`** returns the issue count (capped at 255) so CI can gate on it.
- **`self_update`** URL is built from `BASHDEP_SELF_URL_TEMPLATE` (printf format with one `%s` slot for the ref). Defaults to upstream `main` on this repo.

## Test plan

- [x] `make test` — 106 tests, 158 assertions
- [x] `make sa`
- [x] `make lint`
- [x] One feature per commit; each commit individually green