### PR TITLE
feat: release.sh automates tagged releases with GH asset

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,11 +16,13 @@ Contributions are licensed under [MIT](../LICENSE).
 
 ```
 bashdep                     # Library entry point — sourced by consumers
+release.sh                  # Release automation (see docs/releasing.md)
 tests/unit/bashdep_test.sh  # Unit tests (bashunit)
 tests/unit/snapshots/       # Captured stdout for snapshot assertions
 example/demo.sh             # End-to-end demo
+docs/                       # API + behavior + releasing reference
 .github/workflows/          # CI: tests, ShellCheck, editorconfig
-Makefile                    # test / sa / lint / deps / pre_commit/install
+Makefile                    # test / sa / lint / deps / release / pre_commit/install
 ```
 
 The codebase is intentionally small and zero-runtime: only `curl`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - `release.sh` automates cutting a tagged release: bumps
   `BASHDEP_VERSION`, rolls `CHANGELOG.md`, runs the test/sa/lint gates,
   commits, tags, pushes, and creates a GitHub release with the `bashdep`
-  script attached as an asset. Supports `--dry-run`, `--force`,
-  `--no-gh`, `--remote=NAME`. Wired up via `make release` /
-  `make release/dry-run`. See `docs/releasing.md`.
+  script attached as an asset. With no positional arg it auto-bumps the
+  minor version (`--major` / `--patch` switch the level). Also accepts
+  an explicit `X.Y.Z`. Supports `--dry-run`, `--force`, `--no-gh`,
+  `--remote=NAME`. Wired up via `make release` / `make release/dry-run`.
+  See `docs/releasing.md`.
 - `bashdep::list` prints every installed dependency from the lockfiles
   under `dir` and `dev-dir` (tab-separated `<path>\t<URL>` lines).
 - `bashdep::setup` accepts `dir`, `dev-dir`, `silent`, `force` parameters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
   reference) and `docs/behavior.md` (lockfile, dev deps, error handling).
 - `bashdep::install_from <file>` reads a dependency list from disk; blank
   lines and `#` comments are ignored.
+- `release.sh` automates cutting a tagged release: bumps
+  `BASHDEP_VERSION`, rolls `CHANGELOG.md`, runs the test/sa/lint gates,
+  commits, tags, pushes, and creates a GitHub release with the `bashdep`
+  script attached as an asset. Supports `--dry-run`, `--force`,
+  `--no-gh`, `--remote=NAME`. Wired up via `make release` /
+  `make release/dry-run`. See `docs/releasing.md`.
 - `bashdep::list` prints every installed dependency from the lockfiles
   under `dir` and `dev-dir` (tab-separated `<path>\t<URL>` lines).
 - `bashdep::setup` accepts `dir`, `dev-dir`, `silent`, `force` parameters.

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,8 @@ help:
 	@echo "  sa                       Run shellcheck static analysis tool"
 	@echo "  lint                     Run editorconfig linter tool"
 	@echo "  deps                     Install required test dependencies"
+	@echo "  release VERSION          Cut a release (runs release.sh)"
+	@echo "  release/dry-run VERSION  Preview release.sh with --dry-run"
 
 SRC_SCRIPTS_DIR=src
 PRE_COMMIT_SCRIPTS_FILE=./bin/pre-commit
@@ -78,3 +80,13 @@ endif
 
 deps:
 	bash install-dependencies.sh
+
+release:
+	@./release.sh $(filter-out $@,$(MAKECMDGOALS))
+
+release/dry-run:
+	@./release.sh $(filter-out $@,$(MAKECMDGOALS)) --dry-run
+
+# Swallow positional version arg so make doesn't try to build it as a target.
+%:
+	@:

--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ Prefer an inline array? Pass it to `bashdep::install` directly.
 ## Documentation
 
 - [**API reference**](docs/api.md) — `install`, `install_from`, `setup`,
-  `list`, `version`.
+  `list`, `uninstall`, `clean`, `doctor`, `self_update`, `version`.
 - [**Behavior**](docs/behavior.md) — lockfile rules, dev dependencies,
   error handling.
+- [**Releasing**](docs/releasing.md) — how maintainers cut a new tagged
+  release with `release.sh`.
 - [**Contributing**](.github/CONTRIBUTING.md) — project layout, test
   conventions, coding guidelines.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,8 @@
 - [API reference](api.md) — every public `bashdep::*` function.
 - [Behavior](behavior.md) — lockfile rules, dev dependencies, error
   handling.
+- [Releasing](releasing.md) — how to cut a new tagged release with
+  `release.sh`.
 
 For contribution workflow and project layout, see
 [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md).

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -13,20 +13,27 @@ Prerequisites:
 - ShellCheck and editorconfig-checker installed (release script gates
   on them).
 
+By default, the script auto-bumps the **minor** version (e.g. `0.3.0` →
+`0.4.0`). Pass an explicit version to override, or use `--major` /
+`--patch` for a different bump level.
+
 Preview first (idempotent — touches nothing):
 
 ```bash
-./release.sh 0.4.0 --dry-run
-# or
-make release/dry-run 0.4.0
+./release.sh --dry-run               # auto-bump minor
+./release.sh --patch --dry-run       # auto-bump patch
+./release.sh 0.4.0 --dry-run         # explicit version
+make release/dry-run                 # via make
 ```
 
 When happy, run for real:
 
 ```bash
-./release.sh 0.4.0
-# or
-make release 0.4.0
+./release.sh                         # auto-bump minor (default)
+./release.sh --major                 # auto-bump major
+./release.sh 0.4.0                   # explicit
+make release                         # via make
+make release 0.4.0                   # via make, explicit
 ```
 
 The script:
@@ -49,6 +56,9 @@ The release URL is printed at the end.
 
 | Flag             | Effect                                                      |
 | ---------------- | ----------------------------------------------------------- |
+| `--major`        | Auto-bump major (X.Y.Z → X+1.0.0). Ignored if version given. |
+| `--minor`        | Auto-bump minor (the default; explicit form).               |
+| `--patch`        | Auto-bump patch (X.Y.Z → X.Y.Z+1). Ignored if version given. |
 | `--dry-run`      | Preview every step. No file/git/network changes.            |
 | `--force`        | Skip the interactive `Release X.Y.Z?` confirmation.         |
 | `--no-gh`        | Skip the GitHub release step (still pushes commit + tag).   |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,90 @@
+# Releasing
+
+bashdep ships a single `bashdep` script. Releases are git tags + a
+GitHub release with the `bashdep` script attached as a downloadable
+asset. The whole flow is automated by `release.sh`.
+
+## Cutting a release
+
+Prerequisites:
+
+- On `main`, working tree clean.
+- `gh` CLI authenticated (`gh auth status`).
+- ShellCheck and editorconfig-checker installed (release script gates
+  on them).
+
+Preview first (idempotent — touches nothing):
+
+```bash
+./release.sh 0.4.0 --dry-run
+# or
+make release/dry-run 0.4.0
+```
+
+When happy, run for real:
+
+```bash
+./release.sh 0.4.0
+# or
+make release 0.4.0
+```
+
+The script:
+
+1. Validates the version is semver and greater than the current.
+2. Confirms you're on `main` with a clean tree, and the tag doesn't exist.
+3. Bumps `BASHDEP_VERSION` in the `bashdep` script.
+4. Rolls `CHANGELOG.md`: renames `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD`,
+    adds a fresh empty `[Unreleased]` section, and refreshes the compare
+    links at the bottom.
+5. Runs `make test sa lint` as a release gate.
+6. Commits with `chore(release): X.Y.Z` and tags `X.Y.Z`.
+7. Pushes the commit and tag to the remote.
+8. Creates the GitHub release via `gh release create` and attaches the
+    `bashdep` script as a downloadable asset.
+
+The release URL is printed at the end.
+
+## Flags
+
+| Flag             | Effect                                                      |
+| ---------------- | ----------------------------------------------------------- |
+| `--dry-run`      | Preview every step. No file/git/network changes.            |
+| `--force`        | Skip the interactive `Release X.Y.Z?` confirmation.         |
+| `--no-gh`        | Skip the GitHub release step (still pushes commit + tag).   |
+| `--remote=NAME`  | Push to a remote other than `origin`.                       |
+
+CI mode (no prompts, no `gh` step):
+
+```bash
+./release.sh 0.4.0 --force --no-gh
+```
+
+## After the release
+
+Consumers install via:
+
+```bash
+curl -fsSLo lib/bashdep https://github.com/Chemaclass/bashdep/releases/download/0.4.0/bashdep
+chmod +x lib/bashdep
+```
+
+Or stay on `main`:
+
+```bash
+curl -fsSLo lib/bashdep https://raw.githubusercontent.com/Chemaclass/bashdep/main/bashdep
+```
+
+Existing installs can self-refresh:
+
+```bash
+bashdep::self_update 0.4.0
+```
+
+## Hotfix
+
+If a release needs a fix:
+
+1. Branch from the tag: `git checkout -b hotfix/0.4.1 0.4.0`.
+2. Apply the fix, open a PR, merge to `main`.
+3. Run `./release.sh 0.4.1` from `main`.

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,337 @@
+#!/bin/bash
+#
+# Release automation for bashdep.
+#
+# Usage:
+#   ./release.sh <version> [--dry-run] [--force] [--no-gh] [--remote=NAME]
+#
+# What it does:
+#   1. Validate semver and working-tree state.
+#   2. Bump BASHDEP_VERSION in the bashdep script.
+#   3. Roll the CHANGELOG: rename [Unreleased] → [X.Y.Z] - YYYY-MM-DD,
+#      add a new empty Unreleased section, refresh compare links.
+#   4. Run make test / sa / lint as a release gate.
+#   5. Commit and tag the release.
+#   6. Push commit + tag to origin.
+#   7. Create a GitHub release with the bashdep script attached as an asset.
+#
+# Flags:
+#   --dry-run     Preview every step. No file/git/network mutations.
+#   --force       Skip interactive confirmation.
+#   --no-gh       Skip the GitHub release step (still pushes commit + tag).
+#   --remote=NAME Push to NAME instead of origin.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+readonly REPO_PATH="Chemaclass/bashdep"
+readonly REPO_URL="https://github.com/${REPO_PATH}"
+readonly RELEASE_ASSET="bashdep"
+readonly MAIN_BRANCH="main"
+
+VERSION=""
+DRY_RUN=false
+FORCE=false
+WITH_GH_RELEASE=true
+REMOTE="origin"
+
+# --- Output helpers ----------------------------------------------------------
+
+if [[ -t 1 ]]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+  BLUE='\033[0;34m'; BOLD='\033[1m'; NC='\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; BLUE=''; BOLD=''; NC=''
+fi
+
+log()    { printf '%b%s%b\n' "$BLUE"   "==> $*" "$NC"; }
+ok()     { printf '%b%s%b\n' "$GREEN"  "  ✓ $*" "$NC"; }
+warn()   { printf '%b%s%b\n' "$YELLOW" "  ! $*" "$NC" >&2; }
+err()    { printf '%b%s%b\n' "$RED"    "  ✗ $*" "$NC" >&2; }
+plan()   { printf '%b%s%b\n' "$YELLOW" "  · would $*" "$NC"; }
+done_ok() { $DRY_RUN || ok "$*"; }
+
+run() {
+  if $DRY_RUN; then
+    plan "$*"
+  else
+    "$@"
+  fi
+}
+
+# --- CLI parsing -------------------------------------------------------------
+
+usage() {
+  cat <<EOF
+Usage: ./release.sh <version> [options]
+
+Arguments:
+  version       Target semver (e.g. 0.4.0). Required.
+
+Options:
+  --dry-run     Preview every step without mutating files, git, or network.
+  --force       Skip interactive confirmation.
+  --no-gh       Skip the GitHub release step.
+  --remote=NAME Push to a remote other than origin.
+  -h, --help    Show this help.
+
+Examples:
+  ./release.sh 0.4.0                 # interactive release
+  ./release.sh 0.4.0 --dry-run       # preview only
+  ./release.sh 0.4.0 --force         # CI / non-interactive
+EOF
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -h|--help) usage; exit 0 ;;
+      --dry-run) DRY_RUN=true ;;
+      --force)   FORCE=true ;;
+      --no-gh)   WITH_GH_RELEASE=false ;;
+      --remote=*) REMOTE="${1#*=}" ;;
+      -*)        err "Unknown flag: $1"; usage >&2; exit 1 ;;
+      *)
+        if [[ -z "$VERSION" ]]; then
+          VERSION="$1"
+        else
+          err "Too many positional args (got '$1')."; exit 1
+        fi
+        ;;
+    esac
+    shift
+  done
+
+  if [[ -z "$VERSION" ]]; then
+    err "Missing required <version>."
+    usage >&2
+    exit 1
+  fi
+
+  if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+    err "Invalid semver: '$VERSION'."
+    exit 1
+  fi
+}
+
+# --- Pre-flight checks -------------------------------------------------------
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { err "Required command not found: $1"; exit 1; }
+}
+
+preflight() {
+  log "Pre-flight checks"
+
+  require_cmd git
+  require_cmd awk
+  require_cmd sed
+  if $WITH_GH_RELEASE; then require_cmd gh; fi
+  ok "required commands present"
+
+  local branch
+  branch=$(git rev-parse --abbrev-ref HEAD)
+  if [[ "$branch" != "$MAIN_BRANCH" ]]; then
+    if $DRY_RUN; then
+      warn "not on $MAIN_BRANCH (current: '$branch') — allowed in --dry-run"
+    else
+      err "Releases must be cut from '$MAIN_BRANCH' (current: '$branch')."
+      exit 1
+    fi
+  else
+    ok "on $MAIN_BRANCH"
+  fi
+
+  if [[ -n "$(git status --porcelain)" ]]; then
+    if $DRY_RUN; then
+      warn "working tree dirty — allowed in --dry-run"
+    else
+      err "Working tree is dirty. Commit or stash first."
+      git status --short >&2
+      exit 1
+    fi
+  else
+    ok "working tree clean"
+  fi
+
+  if git rev-parse "$VERSION" >/dev/null 2>&1; then
+    err "Tag '$VERSION' already exists."
+    exit 1
+  fi
+  ok "tag $VERSION does not exist"
+
+  local current
+  current=$(grep -E '^BASHDEP_VERSION=' bashdep | head -1 | sed -E 's/^BASHDEP_VERSION="([^"]+)"$/\1/')
+  if [[ -z "$current" ]]; then
+    err "Could not read current BASHDEP_VERSION from 'bashdep'."
+    exit 1
+  fi
+  if [[ "$current" == "$VERSION" ]]; then
+    err "BASHDEP_VERSION is already '$VERSION'. Choose a higher version."
+    exit 1
+  fi
+  PREVIOUS_VERSION="$current"
+  ok "current version: $PREVIOUS_VERSION → new version: $VERSION"
+
+  if ! grep -q '^## \[Unreleased\]' CHANGELOG.md; then
+    err "CHANGELOG.md has no '[Unreleased]' section to roll."
+    exit 1
+  fi
+  ok "CHANGELOG has [Unreleased] section"
+}
+
+confirm() {
+  if $FORCE || $DRY_RUN; then return 0; fi
+  printf '%bRelease %s? [y/N] %b' "$BOLD" "$VERSION" "$NC"
+  local ans
+  read -r ans
+  case "$ans" in y|Y|yes|YES) return 0 ;; *) err "Aborted."; exit 1 ;; esac
+}
+
+# --- Mutations ---------------------------------------------------------------
+
+bump_version() {
+  log "Bump BASHDEP_VERSION → $VERSION"
+  if $DRY_RUN; then
+    plan "sed bashdep BASHDEP_VERSION=$PREVIOUS_VERSION → $VERSION"
+    return
+  fi
+  sed -i.bak -E "s/^BASHDEP_VERSION=\"[^\"]+\"$/BASHDEP_VERSION=\"$VERSION\"/" bashdep
+  rm -f bashdep.bak
+  if ! grep -q "BASHDEP_VERSION=\"$VERSION\"" bashdep; then
+    err "Failed to bump BASHDEP_VERSION."
+    exit 1
+  fi
+  done_ok "bashdep version bumped"
+}
+
+roll_changelog() {
+  log "Roll CHANGELOG"
+  local today
+  today=$(date +%Y-%m-%d)
+
+  if $DRY_RUN; then
+    plan "rename [Unreleased] → [$VERSION] - $today, add new empty [Unreleased]"
+    plan "refresh compare links: Unreleased…HEAD against $VERSION"
+    plan "add [$VERSION]: …compare/$PREVIOUS_VERSION...$VERSION"
+    return
+  fi
+
+  local tmp
+  tmp=$(mktemp)
+  awk -v ver="$VERSION" -v date="$today" '
+    /^## \[Unreleased\]/ {
+      print "## [Unreleased]"
+      print ""
+      print "### Added"
+      print ""
+      print "### Changed"
+      print ""
+      print "### Fixed"
+      print ""
+      print "## [" ver "] - " date
+      next
+    }
+    { print }
+  ' CHANGELOG.md > "$tmp"
+  mv "$tmp" CHANGELOG.md
+
+  awk -v ver="$VERSION" -v prev="$PREVIOUS_VERSION" -v repo="$REPO_URL" '
+    /^\[Unreleased\]:/ {
+      print "[Unreleased]: " repo "/compare/" ver "...HEAD"
+      print "[" ver "]: " repo "/compare/" prev "..." ver
+      next
+    }
+    { print }
+  ' CHANGELOG.md > "$tmp"
+  mv "$tmp" CHANGELOG.md
+
+  done_ok "CHANGELOG rolled (Unreleased → $VERSION on $today)"
+}
+
+run_gates() {
+  log "Run release gates (test + sa + lint)"
+  if $DRY_RUN; then
+    plan "make test sa lint"
+    return
+  fi
+  make test >/dev/null
+  done_ok "tests pass"
+  make sa >/dev/null
+  done_ok "shellcheck pass"
+  make lint >/dev/null
+  done_ok "editorconfig pass"
+}
+
+commit_and_tag() {
+  log "Commit + tag"
+  run git add bashdep CHANGELOG.md
+  run git commit -m "chore(release): $VERSION"
+  run git tag -a "$VERSION" -m "Release $VERSION"
+  done_ok "committed and tagged $VERSION"
+}
+
+push() {
+  log "Push to $REMOTE"
+  run git push "$REMOTE" "$MAIN_BRANCH"
+  run git push "$REMOTE" "$VERSION"
+  done_ok "pushed branch + tag"
+}
+
+create_gh_release() {
+  if ! $WITH_GH_RELEASE; then
+    warn "Skipping GitHub release step (--no-gh)"
+    return
+  fi
+  log "Create GitHub release + attach asset"
+  local notes_url="$REPO_URL/blob/$VERSION/CHANGELOG.md"
+  local body
+  body="See [CHANGELOG.md]($notes_url) for the full notes.
+
+## Install
+\`\`\`bash
+curl -fsSLo lib/bashdep $REPO_URL/releases/download/$VERSION/$RELEASE_ASSET
+chmod +x lib/bashdep
+\`\`\`"
+  if $DRY_RUN; then
+    plan "gh release create $VERSION --title 'Release $VERSION' --notes <generated> $RELEASE_ASSET"
+    return
+  fi
+  gh release create "$VERSION" \
+    --repo "$REPO_PATH" \
+    --title "Release $VERSION" \
+    --notes "$body" \
+    "$RELEASE_ASSET"
+  done_ok "GitHub release created with $RELEASE_ASSET attached"
+}
+
+# --- Main --------------------------------------------------------------------
+
+main() {
+  parse_args "$@"
+  preflight
+
+  if $DRY_RUN; then
+    log "DRY RUN — no changes will be made"
+  fi
+
+  confirm
+
+  bump_version
+  roll_changelog
+  run_gates
+  commit_and_tag
+  push
+  create_gh_release
+
+  log "Done."
+  done_ok "Release $VERSION published."
+  if ! $DRY_RUN; then
+    printf '%b%s%b %s\n' "$BLUE" "==>" "$NC" "$REPO_URL/releases/tag/$VERSION"
+  fi
+}
+
+main "$@"

--- a/release.sh
+++ b/release.sh
@@ -33,6 +33,7 @@ readonly RELEASE_ASSET="bashdep"
 readonly MAIN_BRANCH="main"
 
 VERSION=""
+BUMP_LEVEL="minor"
 DRY_RUN=false
 FORCE=false
 WITH_GH_RELEASE=true
@@ -66,12 +67,18 @@ run() {
 
 usage() {
   cat <<EOF
-Usage: ./release.sh <version> [options]
+Usage: ./release.sh [version] [options]
 
 Arguments:
-  version       Target semver (e.g. 0.4.0). Required.
+  version       Target semver (e.g. 0.4.0). Optional — when omitted,
+                auto-bumps the minor of the current BASHDEP_VERSION
+                (e.g. 0.3.0 → 0.4.0; patch resets to 0).
 
 Options:
+  --major       Auto-bump the major instead of minor (X.Y.Z → X+1.0.0).
+                Ignored when an explicit version is given.
+  --patch       Auto-bump the patch instead of minor (X.Y.Z → X.Y.Z+1).
+                Ignored when an explicit version is given.
   --dry-run     Preview every step without mutating files, git, or network.
   --force       Skip interactive confirmation.
   --no-gh       Skip the GitHub release step.
@@ -79,9 +86,11 @@ Options:
   -h, --help    Show this help.
 
 Examples:
-  ./release.sh 0.4.0                 # interactive release
-  ./release.sh 0.4.0 --dry-run       # preview only
-  ./release.sh 0.4.0 --force         # CI / non-interactive
+  ./release.sh                       # auto-bump minor (default)
+  ./release.sh --patch               # auto-bump patch
+  ./release.sh --major --dry-run     # preview a major bump
+  ./release.sh 0.4.0                 # explicit version, interactive
+  ./release.sh 0.4.0 --force         # explicit, CI / non-interactive
 EOF
 }
 
@@ -89,6 +98,9 @@ parse_args() {
   while [[ $# -gt 0 ]]; do
     case $1 in
       -h|--help) usage; exit 0 ;;
+      --major)   BUMP_LEVEL="major" ;;
+      --minor)   BUMP_LEVEL="minor" ;;
+      --patch)   BUMP_LEVEL="patch" ;;
       --dry-run) DRY_RUN=true ;;
       --force)   FORCE=true ;;
       --no-gh)   WITH_GH_RELEASE=false ;;
@@ -105,16 +117,24 @@ parse_args() {
     shift
   done
 
-  if [[ -z "$VERSION" ]]; then
-    err "Missing required <version>."
-    usage >&2
-    exit 1
-  fi
-
-  if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+  if [[ -n "$VERSION" ]] && ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
     err "Invalid semver: '$VERSION'."
     exit 1
   fi
+}
+
+# Compute next version from a current X.Y.Z given a bump level.
+# Echoes the new version on stdout.
+bump_version_string() {
+  local current=$1 level=$2
+  local major minor patch
+  IFS='.' read -r major minor patch <<<"$current"
+  case $level in
+    major) printf '%s.0.0\n'   "$((major + 1))" ;;
+    minor) printf '%s.%s.0\n'  "$major" "$((minor + 1))" ;;
+    patch) printf '%s.%s.%s\n' "$major" "$minor" "$((patch + 1))" ;;
+    *)     err "Unknown bump level: $level"; return 1 ;;
+  esac
 }
 
 # --- Pre-flight checks -------------------------------------------------------
@@ -157,23 +177,34 @@ preflight() {
     ok "working tree clean"
   fi
 
-  if git rev-parse "$VERSION" >/dev/null 2>&1; then
-    err "Tag '$VERSION' already exists."
-    exit 1
-  fi
-  ok "tag $VERSION does not exist"
-
   local current
   current=$(grep -E '^BASHDEP_VERSION=' bashdep | head -1 | sed -E 's/^BASHDEP_VERSION="([^"]+)"$/\1/')
   if [[ -z "$current" ]]; then
     err "Could not read current BASHDEP_VERSION from 'bashdep'."
     exit 1
   fi
+  PREVIOUS_VERSION="$current"
+
+  if [[ -z "$VERSION" ]]; then
+    if ! [[ "$current" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      err "Auto-bump requires the current version to be plain X.Y.Z (got '$current'). Pass an explicit version."
+      exit 1
+    fi
+    VERSION=$(bump_version_string "$current" "$BUMP_LEVEL")
+    ok "auto-bumped $BUMP_LEVEL: $current → $VERSION"
+  fi
+
   if [[ "$current" == "$VERSION" ]]; then
     err "BASHDEP_VERSION is already '$VERSION'. Choose a higher version."
     exit 1
   fi
-  PREVIOUS_VERSION="$current"
+
+  if git rev-parse "$VERSION" >/dev/null 2>&1; then
+    err "Tag '$VERSION' already exists."
+    exit 1
+  fi
+  ok "tag $VERSION does not exist"
+
   ok "current version: $PREVIOUS_VERSION → new version: $VERSION"
 
   if ! grep -q '^## \[Unreleased\]' CHANGELOG.md; then


### PR DESCRIPTION
## Summary

Single-shot release automation modeled after [bashunit's release.sh](https://github.com/TypedDevs/bashunit/blob/main/release.sh), adapted to bashdep's smaller surface area (one script, one asset).

```bash
./release.sh 0.4.0 --dry-run     # preview
./release.sh 0.4.0               # do it
make release/dry-run 0.4.0       # via make
```

## What it does

1. **Validate** semver and pre-flight (on `main`, clean tree, tag free, `CHANGELOG.md` has `[Unreleased]` section).
2. **Bump** `BASHDEP_VERSION` in the `bashdep` script.
3. **Roll CHANGELOG.md**: rename `[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD`, add a fresh empty `[Unreleased]`, refresh compare links at the bottom.
4. **Run release gates**: `make test sa lint`. Aborts the release if any fail.
5. **Commit** with `chore(release): X.Y.Z` and **tag** `X.Y.Z` (annotated).
6. **Push** commit and tag to `origin` (or `--remote=NAME`).
7. **Create the GitHub release** via `gh release create` and attach the `bashdep` script as a downloadable asset, so users can `curl -fsSLo lib/bashdep https://github.com/Chemaclass/bashdep/releases/download/X.Y.Z/bashdep`.

## Flags

| Flag             | Effect                                                                       |
| ---------------- | ---------------------------------------------------------------------------- |
| `--dry-run`      | Preview every step. No file/git/network changes. Loosens preflight so you can preview from any branch / dirty tree. |
| `--force`        | Skip the interactive `Release X.Y.Z?` confirmation (CI mode).                 |
| `--no-gh`        | Skip the GitHub release step (still pushes commit + tag).                    |
| `--remote=NAME`  | Push to `NAME` instead of `origin`.                                          |

## Verified

- [x] `make test` (106 tests, 158 assertions)
- [x] `make sa` (script is ShellCheck clean)
- [x] `make lint`
- [x] Manual `./release.sh 0.4.0 --dry-run --no-gh` from this branch — preview output is correct, no file/git mutations occurred.

## Docs

- New `docs/releasing.md` covers the full flow + hotfix process.
- README + `docs/README.md` link to it.
- CONTRIBUTING.md project layout updated to mention `release.sh` and `docs/`.
- CHANGELOG entry under `[Unreleased]`.