### PR TITLE
fix(clean,doctor): never touch the bashdep script itself

### DIFF
--- a/bashdep
+++ b/bashdep
@@ -157,13 +157,15 @@ function bashdep::uninstall() {
 }
 
 # Remove orphan files: anything in BASHDEP_DIR or BASHDEP_DEV_DIR that
-# isn't recorded in the local .bashdep.lock and isn't the lockfile itself.
-# Skips directories with no lockfile (a missing lockfile is treated as
-# 'don't manage this dir', not 'every file is an orphan').
-# In dry-run mode, prints intended removals without touching disk.
-# Returns 0 always; failures from individual rm calls are not propagated.
+# isn't recorded in the local .bashdep.lock and isn't the lockfile or the
+# bashdep script itself. Skips directories with no lockfile (a missing
+# lockfile is treated as 'don't manage this dir', not 'every file is an
+# orphan'). In dry-run mode, prints intended removals without touching
+# disk. Returns 0 always; failures from individual rm calls are not
+# propagated.
 function bashdep::clean() {
   local removed=0
+  local self_name="${BASH_SOURCE[0]##*/}"
   local dir lock_file file_path file_name seen=""
   for dir in "$BASHDEP_DIR" "$BASHDEP_DEV_DIR"; do
     [[ -z "$dir" || ! -d "$dir" ]] && continue
@@ -175,6 +177,7 @@ function bashdep::clean() {
       [[ -f "$file_path" ]] || continue
       file_name="${file_path##*/}"
       [[ "$file_name" == "$BASHDEP_LOCK_FILE" ]] && continue
+      [[ "$file_name" == "$self_name" ]] && continue
       [[ -n "$(bashdep::_lock_get "$lock_file" "$file_name")" ]] && continue
       if bashdep::is_dry_run; then
         bashdep::_log "[dry-run] Would remove orphan '$file_path'"
@@ -195,6 +198,7 @@ function bashdep::clean() {
 # count, capped at 255. Returns 0 when everything is consistent.
 function bashdep::doctor() {
   local issues=0
+  local self_name="${BASH_SOURCE[0]##*/}"
   local dir lock_file file_path file_name entry_name entry_url seen=""
   for dir in "$BASHDEP_DIR" "$BASHDEP_DEV_DIR"; do
     [[ -z "$dir" || ! -d "$dir" ]] && continue
@@ -217,6 +221,7 @@ function bashdep::doctor() {
       [[ -f "$file_path" ]] || continue
       file_name="${file_path##*/}"
       [[ "$file_name" == "$BASHDEP_LOCK_FILE" ]] && continue
+      [[ "$file_name" == "$self_name" ]] && continue
       if [[ -z "$(bashdep::_lock_get "$lock_file" "$file_name")" ]]; then
         bashdep::_log "  orphan file '$file_path' (no lockfile entry)"
         issues=$((issues + 1))

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -890,6 +890,29 @@ function test_bashdep_clean_dry_run_preserves_files() {
   assert_file_exists "$TEST_DIR/orphan"
 }
 
+function test_bashdep_clean_does_not_remove_bashdep_script_itself() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" tracked https://example.com/tracked
+  cp "$(current_dir)/../../bashdep" "$TEST_DIR/bashdep"
+  touch "$TEST_DIR/orphan"
+
+  bashdep::clean >/dev/null
+  assert_file_exists     "$TEST_DIR/bashdep"
+  assert_file_exists     "$TEST_DIR/tracked"
+  assert_file_not_exists "$TEST_DIR/orphan"
+}
+
+function test_bashdep_doctor_does_not_flag_bashdep_script_itself() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" tracked https://example.com/tracked
+  cp "$(current_dir)/../../bashdep" "$TEST_DIR/bashdep"
+
+  local output
+  output=$(bashdep::doctor)
+  assert_successful_code "$?"
+  assert_not_contains "bashdep" "$output"
+}
+
 function test_bashdep_clean_handles_both_dirs() {
   BASHDEP_DIR="$TEST_DIR/main"
   BASHDEP_DEV_DIR="$TEST_DIR/dev"


### PR DESCRIPTION
## Summary

Senior-QA acceptance run against the published 0.4.0 release surfaced a real footgun: the README's recommended layout puts \`bashdep\` at \`lib/bashdep\`, but \`lib/\` is also the default \`\$BASHDEP_DIR\`. Before this fix:

- \`bashdep::doctor\` flagged \`lib/bashdep\` as an orphan (no lockfile entry) and returned a non-zero issue count.
- \`bashdep::clean\` happily \`rm -f\`ed \`lib/bashdep\` along with other orphans, silently breaking the user's tool on a routine \`clean\`.

This is the exact pattern the README quick-start tells users to follow:

```bash
mkdir -p lib
curl -fsSLo lib/bashdep https://...
chmod +x lib/bashdep
```

## Fix

Both \`clean\` and \`doctor\` now skip any file whose basename matches \`\${BASH_SOURCE[0]##*/}\` — the running bashdep script's own name. Using the basename of \`BASH_SOURCE\` (rather than hardcoding \`bashdep\`) handles users who deploy the script under a different filename.

## Tests

Two new tests scaffold a real bashdep copy inside \`\$TEST_DIR\` and verify:

- \`clean\` preserves the bashdep script while still removing other orphans.
- \`doctor\` returns 0 (and produces no \"bashdep\" mention in its output) when the script lives in the managed directory alongside tracked deps.

Plus a 47-step \`/tmp\` end-to-end QA run that previously caught the bug now passes against this branch's \`bashdep\`.

## Test plan

- [x] \`make test\` (108 tests, 163 assertions)
- [x] \`make sa\`
- [x] \`make lint\`
- [x] Manual QA against \`/tmp/qa_release\` with local HTTP server fixtures
- [ ] Cut \`0.4.1\` after merge