### PR TITLE
fix: _vlog returns 0 when verbose=false (regression in install rc)

### DIFF
--- a/bashdep
+++ b/bashdep
@@ -369,8 +369,10 @@ function bashdep::_log() {
 }
 
 # Internal: print only when verbose mode is on (and silent is off).
+# Always returns 0 — "not verbose" is a normal state, not a failure.
 function bashdep::_vlog() {
-  bashdep::is_verbose && bashdep::_log "$@"
+  if bashdep::is_verbose; then bashdep::_log "$@"; fi
+  return 0
 }
 
 # Internal: return 0 when an existing dependency can be reused.

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -572,6 +572,59 @@ function test_bashdep_download_url_curl_failure_returns_non_zero() {
   assert_general_error
 }
 
+function test_bashdep_download_url_returns_zero_on_success() {
+  # shellcheck disable=SC2016
+  mock curl 'touch "$4"'
+  bashdep::download_url "https://example.com/tool" "$TEST_DIR" >/dev/null
+  assert_successful_code "$?"
+}
+
+function test_bashdep_download_url_returns_zero_when_verbose_off() {
+  # shellcheck disable=SC2016
+  mock curl 'touch "$4"'
+  BASHDEP_VERBOSE=false
+  bashdep::download_url "https://example.com/tool" "$TEST_DIR" >/dev/null
+  assert_successful_code "$?"
+}
+
+function test_bashdep_download_url_returns_zero_when_verbose_on() {
+  # shellcheck disable=SC2016
+  mock curl 'touch "$4"'
+  BASHDEP_VERBOSE=true
+  bashdep::download_url "https://example.com/tool" "$TEST_DIR" >/dev/null
+  assert_successful_code "$?"
+}
+
+function test_bashdep_install_returns_zero_after_real_download() {
+  # shellcheck disable=SC2016
+  mock curl 'touch "$4"'
+  BASHDEP_DIR="$TEST_DIR"
+  bashdep::install "https://example.com/a" >/dev/null
+  assert_successful_code "$?"
+}
+
+function test_bashdep_install_from_returns_zero_after_real_download() {
+  local file="$TEST_DIR/.bashdep"
+  printf 'https://example.com/a\n' > "$file"
+  # shellcheck disable=SC2016
+  mock curl 'touch "$4"'
+  BASHDEP_DIR="$TEST_DIR"
+  bashdep::install_from "$file" >/dev/null
+  assert_successful_code "$?"
+}
+
+function test_bashdep_vlog_returns_zero_when_verbose_off() {
+  BASHDEP_VERBOSE=false
+  bashdep::_vlog hi
+  assert_successful_code "$?"
+}
+
+function test_bashdep_vlog_returns_zero_when_verbose_on() {
+  BASHDEP_VERBOSE=true
+  bashdep::_vlog hi >/dev/null
+  assert_successful_code "$?"
+}
+
 function test_bashdep_download_url_writes_lockfile_entry() {
   local url="https://example.com/tool"
   mock curl "true"


### PR DESCRIPTION
## Summary

Senior-QA acceptance run against 0.4.1 (with the README quick-start layout) caught a deeper bug than the clean/doctor self-exclusion fix:

\`bashdep::_vlog\` ended with the chain \`bashdep::is_verbose && bashdep::_log "\$@"\`. When verbose is off (the default), \`is_verbose\` returns 1, the chain short-circuits with rc=1, and that becomes the function's exit code. \`_vlog\` is the **last statement of \`bashdep::download_url\`** (\`  lockfile: \$lock_file\` line, added with the verbose-mode commit), so \`download_url\` returned 1 on every successful download.

\`bashdep::install\` then counted each successful install as a failure:

\`\`\`bash
bashdep::download_url ... || failures=\$((failures + 1))
\`\`\`

So \`install\` returned the number of "failures" (= number of installed deps) and \`install_from\` propagated it. Real-world impact:

\`\`\`bash
source lib/bashdep
bashdep::install_from .bashdep || exit \$?   # exits 1 on a perfectly successful install
\`\`\`

## Why unit tests missed it

No test asserted \`download_url\` returns 0 on a real successful download:

- \`test_bashdep_install_returns_zero_when_all_succeed\` mocks both \`setup_directory\` and \`download_url\` to \`return 0\`, bypassing the real path.
- Snapshot tests check stdout, not the function's rc.
- \`test_bashdep_download_url_writes_lockfile_entry\` checks file state, not rc.

The bug only fired when verbose was off (default) AND a real download path ran end-to-end. Mocked download_url tests never exercised \`_vlog\`.

## Fix

\`\`\`bash
function bashdep::_vlog() {
  if bashdep::is_verbose; then bashdep::_log "\$@"; fi
  return 0
}
\`\`\`

Always return 0 — "not verbose" is a normal state, not a failure.

## New tests (7)

- \`download_url\` returns 0 on success (default path)
- \`download_url\` returns 0 with verbose=false
- \`download_url\` returns 0 with verbose=true
- \`install\` returns 0 after a real download (not mocked)
- \`install_from\` returns 0 after a real download
- \`_vlog\` returns 0 with verbose=false
- \`_vlog\` returns 0 with verbose=true

## Test plan

- [x] \`make test\` (115 tests, 170 assertions)
- [x] \`make sa\`
- [x] \`make lint\`
- [x] Reproduced the bug with \`bashdep::install_from .bashdep || exit \$?\` against the published 0.4.1; confirmed fixed on this branch.
- [ ] Cut 0.4.2 after merge