### PR TITLE
feat(cli): run bashdep as an executable CLI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -88,6 +88,8 @@ All public functions live in the single `bashdep` script under the
 | `bashdep::doctor` | Report missing/orphan inconsistencies |
 | `bashdep::self_update` | Re-download `bashdep` from upstream |
 | `bashdep::version` | Print `BASHDEP_VERSION` |
+| `bashdep::main` | CLI dispatcher (runs when the script is executed, not sourced) |
+| `bashdep::usage` | Print CLI usage/help text |
 
 Private helpers use a leading `_` (`bashdep::_classify_dep`, `_lock_get`, …).
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,8 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: "Install bashunit"
-        run: |
-          curl -s https://bashunit.typeddevs.com/install.sh | bash -s lib 0.17.0
+        run: bash install-dependencies.sh
 
       - name: Run Tests
         run: ${{ matrix.script_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ## [Unreleased]
 
+### Added
+
+- CLI mode: executing `bashdep` directly (not sourced) now dispatches
+  commands — `install`, `list`, `uninstall`, `clean`, `doctor`,
+  `self-update`, `version`, `help`. Flags mirror `bashdep::setup`
+  (`--dir`, `--dev-dir`, `--force`, `--dry-run`, `--silent`,
+  `--verbose`) plus `--file=FILE` for `install`. Exit codes propagate
+  from the underlying functions. Sourcing is unaffected.
+
+### Changed
+
+- `bashdep::install_from` now defaults to `.bashdep` in the current
+  directory when called without arguments (previously it required a
+  file path and returned `1`).
+
 ## [0.4.2] - 2026-05-03
 
 First usable 0.4 release. Supersedes the yanked 0.4.0 and 0.4.1 — see

--- a/README.md
+++ b/README.md
@@ -41,11 +41,23 @@ entry. Commit `.bashdep.lock` to lock versions across collaborators.
 
 Prefer an inline array? Pass it to `bashdep::install` directly.
 
+### Or use the CLI
+
+No wrapper script needed — bashdep is also a CLI:
+
+```bash
+./lib/bashdep install          # reads ./.bashdep
+./lib/bashdep list
+./lib/bashdep doctor
+./lib/bashdep --help
+```
+
 ## Why bashdep?
 
 - **Idempotent installs** via per-directory `.bashdep.lock`.
 - **Dev/prod separation** via the `@dev` URL suffix (`lib/` vs `lib/dev/`).
-- **File-driven or array-driven** — `install_from` or `install`.
+- **File-driven, array-driven, or CLI** — `install_from`, `install`, or
+  `./lib/bashdep <command>`.
 - **Lifecycle commands** — `list`, `uninstall`, `clean`, `doctor`,
   `self_update`.
 - **Modes** — `force`, `dry-run`, `silent`, `verbose`.

--- a/README.md
+++ b/README.md
@@ -9,15 +9,18 @@ Minimal, zero-dependency **bash dependency manager**. Declare URLs;
 bashdep downloads them into `lib/` and keeps installs idempotent via a
 per-directory `.bashdep.lock`. No registry, no runtime — just `curl`.
 
+## Quick start
+
+**1. Vendor bashdep into your repo:**
+
 ```bash
 mkdir -p lib
 curl -fsSLo lib/bashdep https://raw.githubusercontent.com/Chemaclass/bashdep/main/bashdep
 chmod +x lib/bashdep
 ```
 
-## Quick start
-
-`.bashdep`:
+**2. Declare your dependencies in a `.bashdep` file** (one URL per
+line; `#` comments allowed; `@dev` suffix routes to `lib/dev/`):
 
 ```
 https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
@@ -25,32 +28,41 @@ https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
 https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh@dev
 ```
 
-`install-dependencies.sh`:
+**3. Install:**
+
+```bash
+./lib/bashdep install
+```
+
+That's it. The first run downloads everything and writes
+`.bashdep.lock`. Re-runs skip already-installed deps; bumping a URL
+version re-downloads only that entry. Commit `.bashdep.lock` to lock
+versions across collaborators.
+
+Everyday commands:
+
+```bash
+./lib/bashdep list             # what's installed (path + source URL)
+./lib/bashdep doctor           # detect lockfile drift
+./lib/bashdep clean --dry-run  # preview orphan removal
+./lib/bashdep --help           # all commands and flags
+```
+
+### Or source it from a script
+
+Prefer a programmatic setup (custom dirs, inline arrays)? Source
+bashdep and call the same functions:
 
 ```bash
 #!/bin/bash
 set -euo pipefail
 
 source lib/bashdep
-bashdep::install_from .bashdep
+bashdep::install_from   # reads ./.bashdep
 ```
 
-First run downloads everything and writes `.bashdep.lock`. Re-runs skip
-already-installed deps; bumping a URL version re-downloads only that
-entry. Commit `.bashdep.lock` to lock versions across collaborators.
-
-Prefer an inline array? Pass it to `bashdep::install` directly.
-
-### Or use the CLI
-
-No wrapper script needed — bashdep is also a CLI:
-
-```bash
-./lib/bashdep install          # reads ./.bashdep
-./lib/bashdep list
-./lib/bashdep doctor
-./lib/bashdep --help
-```
+See the [API reference](docs/api.md) for `bashdep::setup`,
+`bashdep::install`, and friends.
 
 ## Why bashdep?
 

--- a/bashdep
+++ b/bashdep
@@ -96,14 +96,11 @@ function bashdep::setup() {
 
 # Read a dependency list from a file and install all entries.
 # One URL per line; blank lines and lines starting with `#` are ignored.
-# Leading/trailing whitespace per line is stripped. Returns the failure
-# count (capped at 255), or 1 if the file argument is missing or unreadable.
+# Leading/trailing whitespace per line is stripped. Defaults to `.bashdep`
+# in the current directory when no file is given. Returns the failure
+# count (capped at 255), or 1 if the file is unreadable.
 function bashdep::install_from() {
-  local file=$1
-  if [[ -z "$file" ]]; then
-    echo "Error: install_from requires a file path." >&2
-    return 1
-  fi
+  local file=${1:-.bashdep}
   if [[ ! -f "$file" ]]; then
     echo "Error: dependency file '$file' not found." >&2
     return 1
@@ -452,3 +449,118 @@ function bashdep::_lock_set() {
     return 1
   fi
 }
+
+# Print CLI usage.
+function bashdep::usage() {
+  cat <<'EOF'
+bashdep - minimal bash dependency manager
+
+Usage:
+  bashdep <command> [options] [args]
+
+Commands:
+  install [url...]      Install the given URLs, or read them from a
+                        dependency file when none are given (see --file)
+  list [dir...]         List installed dependencies (path<TAB>url)
+  uninstall <name...>   Remove dependencies and their lockfile entries
+  clean                 Remove files not recorded in the lockfile
+  doctor                Report lockfile/filesystem inconsistencies
+  self-update [ref]     Update bashdep itself (default ref: main)
+  version               Print the bashdep version
+  help                  Show this help
+
+Options:
+  --dir=DIR             Destination directory (default: lib)
+  --dev-dir=DIR         Dev destination directory (default: lib/dev)
+  --file=FILE           Dependency file for install (default: .bashdep)
+  --force               Re-download even when already installed
+  --dry-run             Preview actions without touching disk
+  --silent              Suppress informational output
+  --verbose             Print extra context
+  -h, --help            Show this help
+EOF
+}
+
+# CLI entry point, invoked when the script is executed rather than sourced.
+# Usage:
+#   bashdep <command> [options] [args]
+#
+# Returns: the underlying command's exit code; 1 on unknown command/option
+# or missing required arguments.
+function bashdep::main() {
+  local command="" dep_file=".bashdep"
+  local args=() arg
+
+  for arg in "$@"; do
+    case $arg in
+      -h|--help)   bashdep::usage; return 0 ;;
+      --force)     BASHDEP_FORCE=true ;;
+      --dry-run)   BASHDEP_DRY_RUN=true ;;
+      --silent)    BASHDEP_SILENT=true ;;
+      --verbose)   BASHDEP_VERBOSE=true ;;
+      --dir=*)     BASHDEP_DIR="${arg#*=}" ;;
+      --dev-dir=*) BASHDEP_DEV_DIR="${arg#*=}" ;;
+      --file=*)    dep_file="${arg#*=}" ;;
+      -*)
+        echo "Error: Unknown option '$arg'" >&2
+        return 1
+        ;;
+      *)
+        if [[ -z "$command" ]]; then
+          command="$arg"
+        else
+          args+=("$arg")
+        fi
+        ;;
+    esac
+  done
+
+  case $command in
+    "")
+      bashdep::usage >&2
+      return 1
+      ;;
+    install)
+      if [[ ${#args[@]} -gt 0 ]]; then
+        bashdep::install "${args[@]}"
+      else
+        bashdep::install_from "$dep_file"
+      fi
+      ;;
+    list)
+      bashdep::list ${args[@]+"${args[@]}"}
+      ;;
+    uninstall)
+      if [[ ${#args[@]} -eq 0 ]]; then
+        echo "Error: uninstall requires at least one dependency name." >&2
+        return 1
+      fi
+      bashdep::uninstall "${args[@]}"
+      ;;
+    clean)
+      bashdep::clean
+      ;;
+    doctor)
+      bashdep::doctor
+      ;;
+    self-update)
+      bashdep::self_update ${args[@]+"${args[@]}"}
+      ;;
+    version)
+      bashdep::version
+      ;;
+    help)
+      bashdep::usage
+      ;;
+    *)
+      echo "Error: Unknown command '$command'" >&2
+      bashdep::usage >&2
+      return 1
+      ;;
+  esac
+}
+
+# Run the CLI only when executed directly, never when sourced.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  bashdep::main "$@"
+fi

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,7 @@
 
 Public functions exposed by `source lib/bashdep`.
 
+- [CLI](#cli)
 - [`bashdep::install`](#bashdepinstall)
 - [`bashdep::install_from`](#bashdepinstall_from)
 - [`bashdep::uninstall`](#bashdepuninstall)
@@ -11,6 +12,31 @@ Public functions exposed by `source lib/bashdep`.
 - [`bashdep::setup`](#bashdepsetup)
 - [`bashdep::list`](#bashdeplist)
 - [`bashdep::version`](#bashdepversion)
+
+## CLI
+
+Every command is also available by executing the script directly —
+no `source` needed:
+
+```bash
+./lib/bashdep install                      # install from ./.bashdep
+./lib/bashdep install https://example.com/tool.sh
+./lib/bashdep list
+./lib/bashdep uninstall tool.sh
+./lib/bashdep clean --dry-run
+./lib/bashdep doctor
+./lib/bashdep self-update
+./lib/bashdep --help
+```
+
+Options map 1:1 to [`bashdep::setup`](#bashdepsetup) parameters:
+`--dir=DIR`, `--dev-dir=DIR`, `--force`, `--dry-run`, `--silent`,
+`--verbose`. `install` also accepts `--file=FILE` to point at a
+dependency file other than `.bashdep`.
+
+Exit codes match the underlying function's return value (e.g. `doctor`
+exits with the issue count), so the CLI drops into CI pipelines as-is.
+Sourcing the script never triggers the CLI.
 
 ## `bashdep::install`
 
@@ -30,10 +56,12 @@ Returns the number of failed downloads (0 on success, capped at 255).
 
 Read a dependency list from a file and install every entry. One URL per
 line; blank lines and `#` comments are ignored; leading/trailing
-whitespace is stripped.
+whitespace is stripped. Defaults to `.bashdep` in the current directory
+when called without arguments.
 
 ```bash
-bashdep::install_from .bashdep
+bashdep::install_from            # reads ./.bashdep
+bashdep::install_from deps.txt   # reads a custom file
 ```
 
 Example `.bashdep`:

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,7 @@
 # API reference
 
-Public functions exposed by `source lib/bashdep`.
+Public functions exposed by `source lib/bashdep`. For lockfile rules,
+dev-dependency routing, and error semantics see [Behavior](behavior.md).
 
 - [CLI](#cli)
 - [`bashdep::install`](#bashdepinstall)
@@ -177,5 +178,5 @@ Pipe into `awk` / `cut` for audit and diff tooling.
 Print the bashdep version.
 
 ```bash
-bashdep::version  # 0.3.0
+bashdep::version  # e.g. 0.4.2
 ```

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -55,8 +55,8 @@ both by default.
 
 - `bashdep::install` continues past failed downloads and returns the
   failure count (capped at 255).
-- `bashdep::install_from` returns `1` if the file is missing or
-  unreadable.
+- `bashdep::install_from` returns `1` if the file (default: `.bashdep`)
+  is missing or unreadable.
 - `bashdep::setup` returns `1` on unknown params or non-boolean values
   for `silent` / `force`.
 - `curl` failures print the exit code to stderr (e.g. `22` = HTTP error,

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -1,6 +1,8 @@
 # Behavior
 
-How bashdep decides what to download, where to put it, and when to skip.
+How bashdep decides what to download, where to put it, and when to
+skip. For function signatures and the CLI see the
+[API reference](api.md).
 
 - [Lockfile and idempotency](#lockfile-and-idempotency)
 - [Dev dependencies](#dev-dependencies)

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -11,6 +11,7 @@ function set_up() {
   BASHDEP_DRY_RUN=false
   BASHDEP_VERBOSE=false
   TEST_DIR=$(mktemp -d)
+  BASHDEP_BIN="$(cd "$(current_dir)/../.." && pwd)/bashdep"
 }
 
 function tear_down() {
@@ -670,9 +671,13 @@ function test_bashdep_install_lockfile_contains_all_deps() {
   assert_contains "bbb" "$lock"
 }
 
-function test_bashdep_install_from_requires_file_arg() {
-  bashdep::install_from "" 2>/dev/null
-  assert_general_error
+function test_bashdep_install_from_defaults_to_bashdep_file() {
+  printf 'https://example.com/default-tool\n' > "$TEST_DIR/.bashdep"
+  BASHDEP_DRY_RUN=true
+
+  local output
+  output=$(cd "$TEST_DIR" && bashdep::install_from)
+  assert_contains "default-tool" "$output"
 }
 
 function test_bashdep_install_from_errors_on_missing_file() {
@@ -1081,4 +1086,122 @@ function test_bashdep_install_dev_lockfile_separated_from_main() {
   assert_not_contains "devtool" "$main_lock"
   assert_contains     "devtool" "$dev_lock"
   assert_not_contains "runtime" "$dev_lock"
+}
+
+# CLI tests — run the bashdep script as an executable ($BASHDEP_BIN).
+# Never hit the network: mutating commands always pass --dry-run or
+# operate on seeded fixtures in $TEST_DIR.
+
+function test_bashdep_cli_version_prints_version() {
+  local output
+  output=$(bash "$BASHDEP_BIN" version)
+  assert_equals "$BASHDEP_VERSION" "$output"
+}
+
+function test_bashdep_cli_help_prints_usage() {
+  local output
+  output=$(bash "$BASHDEP_BIN" --help)
+  assert_contains "Usage:" "$output"
+}
+
+function test_bashdep_cli_help_command_prints_usage() {
+  local output
+  output=$(bash "$BASHDEP_BIN" help)
+  assert_contains "Usage:" "$output"
+}
+
+function test_bashdep_cli_no_args_prints_usage_and_fails() {
+  bash "$BASHDEP_BIN" >/dev/null 2>&1
+  assert_general_error
+}
+
+function test_bashdep_cli_unknown_command_fails() {
+  local stderr
+  stderr=$(bash "$BASHDEP_BIN" bogus 2>&1 >/dev/null)
+  assert_contains "Unknown command" "$stderr"
+}
+
+function test_bashdep_cli_unknown_option_fails() {
+  local stderr
+  stderr=$(bash "$BASHDEP_BIN" install --bogus 2>&1 >/dev/null)
+  assert_contains "Unknown option" "$stderr"
+}
+
+function test_bashdep_cli_install_url_dry_run_downloads_nothing() {
+  local output
+  output=$(bash "$BASHDEP_BIN" install --dry-run --dir="$TEST_DIR" \
+    "https://example.com/tool")
+  assert_contains "[dry-run]" "$output"
+  assert_file_not_exists "$TEST_DIR/tool"
+}
+
+function test_bashdep_cli_install_reads_default_bashdep_file() {
+  printf 'https://example.com/from-file\n' > "$TEST_DIR/.bashdep"
+  local output
+  output=$(cd "$TEST_DIR" && bash "$BASHDEP_BIN" install --dry-run)
+  assert_contains "from-file" "$output"
+}
+
+function test_bashdep_cli_install_respects_file_flag() {
+  printf 'https://example.com/custom-tool\n' > "$TEST_DIR/deps.txt"
+  local output
+  output=$(bash "$BASHDEP_BIN" install --dry-run --file="$TEST_DIR/deps.txt")
+  assert_contains "custom-tool" "$output"
+}
+
+function test_bashdep_cli_install_missing_default_file_fails() {
+  local stderr
+  stderr=$(cd "$TEST_DIR" && bash "$BASHDEP_BIN" install 2>&1 >/dev/null)
+  assert_contains "not found" "$stderr"
+}
+
+function test_bashdep_cli_install_silent_suppresses_output() {
+  local output
+  output=$(bash "$BASHDEP_BIN" install --dry-run --silent --dir="$TEST_DIR" \
+    "https://example.com/tool")
+  assert_empty "$output"
+}
+
+function test_bashdep_cli_list_prints_lock_entries() {
+  _seed_installed "$TEST_DIR" tool "https://example.com/tool"
+  local output
+  output=$(bash "$BASHDEP_BIN" list --dir="$TEST_DIR")
+  assert_contains "$TEST_DIR/tool	https://example.com/tool" "$output"
+}
+
+function test_bashdep_cli_uninstall_removes_dep() {
+  _seed_installed "$TEST_DIR" tool "https://example.com/tool"
+  bash "$BASHDEP_BIN" uninstall --dir="$TEST_DIR" tool >/dev/null
+  assert_file_not_exists "$TEST_DIR/tool"
+}
+
+function test_bashdep_cli_uninstall_requires_name() {
+  bash "$BASHDEP_BIN" uninstall --dir="$TEST_DIR" >/dev/null 2>&1
+  assert_general_error
+}
+
+function test_bashdep_cli_clean_removes_orphans() {
+  _seed_installed "$TEST_DIR" kept "https://example.com/kept"
+  touch "$TEST_DIR/orphan"
+  bash "$BASHDEP_BIN" clean --dir="$TEST_DIR" >/dev/null
+  assert_file_not_exists "$TEST_DIR/orphan"
+  assert_file_exists "$TEST_DIR/kept"
+}
+
+function test_bashdep_cli_doctor_exit_code_is_issue_count() {
+  _seed_lock "$TEST_DIR" missing "https://example.com/missing"
+  bash "$BASHDEP_BIN" doctor --dir="$TEST_DIR" >/dev/null
+  assert_general_error
+}
+
+function test_bashdep_cli_self_update_dry_run_prints_intent() {
+  local output
+  output=$(bash "$BASHDEP_BIN" self-update --dry-run)
+  assert_contains "[dry-run] Would update" "$output"
+}
+
+function test_bashdep_sourcing_does_not_invoke_cli() {
+  local output
+  output=$(bash -c "source '$BASHDEP_BIN' && echo SOURCED_OK")
+  assert_equals "SOURCED_OK" "$output"
 }


### PR DESCRIPTION
## Summary

- **CLI mode**: executing `bashdep` directly (not sourced) now dispatches commands — `install`, `list`, `uninstall`, `clean`, `doctor`, `self-update`, `version`, `help`. Flags mirror `bashdep::setup` (`--dir`, `--dev-dir`, `--force`, `--dry-run`, `--silent`, `--verbose`) plus `--file=FILE` for `install`. Exit codes propagate from the underlying functions (e.g. `doctor` exits with the issue count), so the CLI drops into CI pipelines as-is. Sourcing never triggers the CLI.
- **`bashdep::install_from` defaults to `.bashdep`** in the current directory when called without arguments (previously required a file path).

## Test plan

- [x] 18 new tests (TDD, red first): 17 CLI tests driving the script as an executable (dry-run only, no network) + `install_from` default-file test
- [x] Full suite green: 133 tests, 190 assertions
- [x] ShellCheck clean (`make sa`)
- [x] Smoke-tested the whole CLI under macOS `/bin/bash` 3.2.57 (Bash 3.2 compatibility)
- [x] Docs updated: `docs/api.md` (CLI section), `docs/behavior.md`, `README.md`, `CHANGELOG.md`

