### PR TITLE
docs(changelog): tighten Unreleased entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,17 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Added
 
-- CLI mode: executing `bashdep` directly (not sourced) now dispatches
-  commands — `install`, `list`, `uninstall`, `clean`, `doctor`,
-  `self-update`, `version`, `help`. Flags mirror `bashdep::setup`
+- **CLI**: `bashdep` now runs as an executable, not only when sourced.
+  Dispatches `install`, `list`, `uninstall`, `clean`, `doctor`,
+  `self-update`, `version`, and `help`. Flags mirror `bashdep::setup`
   (`--dir`, `--dev-dir`, `--force`, `--dry-run`, `--silent`,
-  `--verbose`) plus `--file=FILE` for `install`. Exit codes propagate
-  from the underlying functions. Sourcing is unaffected.
+  `--verbose`), plus `--file=FILE` for `install`. Exit codes propagate
+  from the underlying functions; sourcing stays side-effect-free.
 
 ### Changed
 
-- `bashdep::install_from` now defaults to `.bashdep` in the current
-  directory when called without arguments (previously it required a
-  file path and returned `1`).
+- `bashdep::install_from` defaults to `.bashdep` in the current
+  directory when called with no argument (previously required a path).
 
 ## [0.4.2] - 2026-05-03
 


### PR DESCRIPTION
## Summary

Copy-edit of the `[Unreleased]` changelog section ahead of the next release — no code changes.

- CLI entry condensed from a dense paragraph into a scannable bullet; same information (commands, flags, exit-code propagation, sourcing unaffected).
- `install_from` "Changed" entry trimmed to the user-facing fact (defaults to `.bashdep` with no argument).

## Test plan

- [x] Docs-only; CI skips tests/ShellCheck on docs-only changes
- [x] `[Unreleased]` header preserved so `release.sh` can still roll it