### PR TITLE
test: cover CLI positional-arg accumulation and flag ordering

### DIFF
--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -1339,3 +1339,45 @@ function test_bashdep_cli_install_curl_failure_exits_nonzero() {
   assert_general_error
   assert_contains "curl exit 7" "$stderr"
 }
+
+# Positional-argument accumulation: the first non-flag token is the
+# command, every later one lands in args[] and is forwarded intact.
+
+function test_bashdep_cli_install_accumulates_multiple_urls() {
+  local output
+  output=$(bash "$BASHDEP_BIN" install --dry-run --dir="$TEST_DIR" \
+    "https://example.com/aaa" "https://example.com/bbb")
+  assert_contains "aaa" "$output"
+  assert_contains "bbb" "$output"
+}
+
+function test_bashdep_cli_uninstall_removes_multiple_names() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" aaa "https://example.com/aaa"
+  printf 'bbb\thttps://example.com/bbb\n' >> "$TEST_DIR/.bashdep.lock"
+  touch "$TEST_DIR/bbb"
+
+  bash "$BASHDEP_BIN" uninstall --dir="$TEST_DIR" aaa bbb >/dev/null
+  assert_file_not_exists "$TEST_DIR/aaa"
+  assert_file_not_exists "$TEST_DIR/bbb"
+}
+
+function test_bashdep_cli_list_forwards_extra_dir_arg() {
+  _seed_lock "$TEST_DIR" main "https://example.com/main"
+  local extra="$TEST_DIR/extra"
+  mkdir -p "$extra"
+  printf 'ex\thttps://example.com/ex\n' > "$extra/.bashdep.lock"
+
+  local output
+  output=$(bash "$BASHDEP_BIN" list --dir="$TEST_DIR" "$extra")
+  assert_contains "$TEST_DIR/main" "$output"
+  assert_contains "$extra/ex" "$output"
+}
+
+function test_bashdep_cli_flag_after_command_still_parsed() {
+  local output
+  output=$(bash "$BASHDEP_BIN" install "https://example.com/tool" \
+    --dry-run --dir="$TEST_DIR")
+  assert_contains "[dry-run]" "$output"
+  assert_contains "$TEST_DIR" "$output"
+}


### PR DESCRIPTION
## Summary

Audit of `bashdep::main` branch coverage found the command/args split (`args+=`) was only exercised with single-argument CLI commands. This PR characterizes the accumulation logic; no production changes.

- Multi-URL `install` — both URLs forwarded to `bashdep::install`
- Multi-name `uninstall` — all names removed
- `list` forwards an extra directory positional arg
- Flag appearing *after* the positional command still parsed (order-independent option loop)

## Test plan

- [x] Suite: 151 tests, 218 assertions, all green (was 147/210)
- [x] No network: dry-run or seeded fixtures throughout
- [x] `make sa` clean