### PR TITLE
feat(release): build a checksummed asset and harden release.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 # third party dependencies
 lib/
 vendor/
+
+# release build output
+dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
   (`--dir`, `--dev-dir`, `--force`, `--dry-run`, `--silent`,
   `--verbose`), plus `--file=FILE` for `install`. Exit codes propagate
   from the underlying functions; sourcing stays side-effect-free.
+- Releases now ship a `checksum` (sha256) asset alongside the `bashdep`
+  script so downloads can be verified.
 
 ### Changed
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,8 +1,9 @@
 # Releasing
 
 bashdep ships a single `bashdep` script. Releases are git tags + a
-GitHub release with the `bashdep` script attached as a downloadable
-asset. The whole flow is automated by `release.sh`.
+GitHub release with two downloadable assets: the `bashdep` script and a
+`checksum` (sha256) to verify it. The whole flow is automated by
+`release.sh`.
 
 ## Cutting a release
 
@@ -38,19 +39,29 @@ make release 0.4.0                   # via make, explicit
 
 The script:
 
-1. Validates the version is semver and greater than the current.
-2. Confirms you're on `main` with a clean tree, and the tag doesn't exist.
-3. Bumps `BASHDEP_VERSION` in the `bashdep` script.
-4. Rolls `CHANGELOG.md`: renames `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD`,
+1. Validates the version is semver and greater than the current, that the
+    required tooling is present (`git`, `awk`, `sed`, `make`, `shellcheck`,
+    `ec`, `shasum`/`sha256sum`, and `gh` unless `--no-gh`), that you're on
+    `main` with a clean tree, that the tag doesn't exist, and that
+    `[Unreleased]` actually has content to ship.
+2. Bumps `BASHDEP_VERSION` in the `bashdep` script.
+3. Rolls `CHANGELOG.md`: renames `[Unreleased]` to `[X.Y.Z] - YYYY-MM-DD`,
     adds a fresh empty `[Unreleased]` section, and refreshes the compare
     links at the bottom.
-5. Runs `make test sa lint` as a release gate.
+4. Runs `make test sa lint` as a release gate.
+5. **Builds the asset** into `dist/`: copies the bumped `bashdep`,
+    syntax-checks it with `bash -n`, and writes a sha256 `checksum`.
 6. Commits with `chore(release): X.Y.Z` and tags `X.Y.Z`.
 7. Pushes the commit and tag to the remote.
-8. Creates the GitHub release via `gh release create` and attaches the
-    `bashdep` script as a downloadable asset.
+8. Creates the GitHub release via `gh release create`, uploads `bashdep`
+    + `checksum`, and verifies both assets attached.
 
-The release URL is printed at the end.
+The release URL is printed at the end. If any step **before the commit**
+fails, the script auto-reverts the file mutations and removes `dist/`;
+after the commit it prints the exact recovery command instead.
+
+The `dist/` build directory is git-ignored — it is a release artifact,
+not source.
 
 ## Flags
 
@@ -77,6 +88,13 @@ Consumers install via:
 ```bash
 curl -fsSLo lib/bashdep https://github.com/Chemaclass/bashdep/releases/download/0.4.0/bashdep
 chmod +x lib/bashdep
+```
+
+Optionally verify the download against the published `checksum` asset:
+
+```bash
+curl -fsSLO https://github.com/Chemaclass/bashdep/releases/download/0.4.0/checksum
+( cd lib && shasum -a 256 -c ../checksum )   # or: sha256sum -c
 ```
 
 Or stay on `main`:

--- a/release.sh
+++ b/release.sh
@@ -6,14 +6,20 @@
 #   ./release.sh <version> [--dry-run] [--force] [--no-gh] [--remote=NAME]
 #
 # What it does:
-#   1. Validate semver and working-tree state.
+#   1. Validate semver, tooling, working-tree state, and CHANGELOG content.
 #   2. Bump BASHDEP_VERSION in the bashdep script.
 #   3. Roll the CHANGELOG: rename [Unreleased] → [X.Y.Z] - YYYY-MM-DD,
 #      add a new empty Unreleased section, refresh compare links.
 #   4. Run make test / sa / lint as a release gate.
-#   5. Commit and tag the release.
-#   6. Push commit + tag to origin.
-#   7. Create a GitHub release with the bashdep script attached as an asset.
+#   5. Build the release asset into dist/: copy the bumped bashdep,
+#      syntax-check it (bash -n), and write a sha256 checksum.
+#   6. Commit and tag the release.
+#   7. Push commit + tag to origin.
+#   8. Create a GitHub release, upload bashdep + checksum, and verify
+#      both assets attached.
+#
+# On failure before the commit, staged file mutations and dist/ are
+# reverted automatically; after the commit, recovery steps are printed.
 #
 # Flags:
 #   --dry-run     Preview every step. No file/git/network mutations.
@@ -25,12 +31,18 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR"
 
 readonly REPO_PATH="Chemaclass/bashdep"
 readonly REPO_URL="https://github.com/${REPO_PATH}"
 readonly RELEASE_ASSET="bashdep"
+readonly DIST_DIR="dist"
+readonly CHECKSUM_FILE="checksum"
 readonly MAIN_BRANCH="main"
+
+# Tracks how far the release has progressed so the cleanup trap knows
+# whether it is safe to auto-revert (before commit) or must only advise
+# (after commit/push). Values: init | mutated | committed | pushed | done.
+STAGE="init"
 
 VERSION=""
 BUMP_LEVEL="minor"
@@ -61,6 +73,32 @@ run() {
   else
     "$@"
   fi
+}
+
+# Print the SHA-256 of a file as "<hash>  <basename>", portable across
+# macOS (shasum) and Linux (sha256sum). Runs from the file's directory so
+# the recorded name is the bare basename, not a path.
+sha256_of() {
+  local path=$1 dir base
+  dir=$(dirname "$path")
+  base=$(basename "$path")
+  if command -v shasum >/dev/null 2>&1; then
+    ( cd "$dir" && shasum -a 256 "$base" )
+  else
+    ( cd "$dir" && sha256sum "$base" )
+  fi
+}
+
+# Return 0 when the [Unreleased] section has at least one non-blank,
+# non-heading line — i.e. there is something to release.
+unreleased_has_content() {
+  awk '
+    /^## \[Unreleased\]/ { in_section = 1; next }
+    /^## \[/            { in_section = 0 }
+    in_section && /^###/ { next }
+    in_section && NF     { found = 1 }
+    END                  { exit found ? 0 : 1 }
+  ' CHANGELOG.md
 }
 
 # --- CLI parsing -------------------------------------------------------------
@@ -143,12 +181,39 @@ require_cmd() {
   command -v "$1" >/dev/null 2>&1 || { err "Required command not found: $1"; exit 1; }
 }
 
+# Like require_cmd, but in --dry-run a missing command only warns — dry-run
+# never actually runs the gates or touches the network, so previewing must
+# not depend on the full release toolchain being installed.
+require_cmd_soft() {
+  command -v "$1" >/dev/null 2>&1 && return 0
+  if $DRY_RUN; then
+    warn "missing '$1' — allowed in --dry-run"
+  else
+    err "Required command not found: $1"
+    exit 1
+  fi
+}
+
 preflight() {
   log "Pre-flight checks"
 
   require_cmd git
   require_cmd awk
   require_cmd sed
+  # Gate + build tools — checked up front so a missing one fails before any
+  # file is mutated, not halfway through run_gates. Soft in dry-run, which
+  # neither runs the gates nor builds.
+  require_cmd_soft make
+  require_cmd_soft shellcheck
+  require_cmd_soft ec
+  if ! command -v shasum >/dev/null 2>&1 && ! command -v sha256sum >/dev/null 2>&1; then
+    if $DRY_RUN; then
+      warn "missing 'shasum'/'sha256sum' — allowed in --dry-run"
+    else
+      err "Need 'shasum' or 'sha256sum' to checksum the release asset."
+      exit 1
+    fi
+  fi
   if $WITH_GH_RELEASE; then require_cmd gh; fi
   ok "required commands present"
 
@@ -211,7 +276,11 @@ preflight() {
     err "CHANGELOG.md has no '[Unreleased]' section to roll."
     exit 1
   fi
-  ok "CHANGELOG has [Unreleased] section"
+  if ! unreleased_has_content; then
+    err "CHANGELOG '[Unreleased]' section is empty — nothing to release."
+    exit 1
+  fi
+  ok "CHANGELOG [Unreleased] has content"
 }
 
 confirm() {
@@ -230,6 +299,7 @@ bump_version() {
     plan "sed bashdep BASHDEP_VERSION=$PREVIOUS_VERSION → $VERSION"
     return
   fi
+  STAGE="mutated"
   sed -i.bak -E "s/^BASHDEP_VERSION=\"[^\"]+\"$/BASHDEP_VERSION=\"$VERSION\"/" bashdep
   rm -f bashdep.bak
   if ! grep -q "BASHDEP_VERSION=\"$VERSION\"" bashdep; then
@@ -297,11 +367,38 @@ run_gates() {
   done_ok "editorconfig pass"
 }
 
+# Stage the release asset into $DIST_DIR: copy the (already version-bumped)
+# bashdep script, syntax-check it, and write a sha256 checksum alongside.
+# Both files are uploaded to the GitHub release. Honors dry-run.
+build_asset() {
+  log "Build release asset"
+  local out="$DIST_DIR/$RELEASE_ASSET"
+  if $DRY_RUN; then
+    plan "stage $RELEASE_ASSET → $out, bash -n, write $DIST_DIR/$CHECKSUM_FILE"
+    return
+  fi
+
+  rm -rf "$DIST_DIR"
+  mkdir -p "$DIST_DIR"
+  cp "$RELEASE_ASSET" "$out"
+  chmod +x "$out"
+
+  if ! bash -n "$out"; then
+    err "Built asset failed 'bash -n' syntax check: $out"
+    exit 1
+  fi
+  done_ok "asset syntax valid"
+
+  sha256_of "$out" > "$DIST_DIR/$CHECKSUM_FILE"
+  done_ok "checksum written ($DIST_DIR/$CHECKSUM_FILE)"
+}
+
 commit_and_tag() {
   log "Commit + tag"
   run git add bashdep CHANGELOG.md
   run git commit -m "chore(release): $VERSION"
   run git tag -a "$VERSION" -m "Release $VERSION"
+  STAGE="committed"
   done_ok "committed and tagged $VERSION"
 }
 
@@ -309,6 +406,7 @@ push() {
   log "Push to $REMOTE"
   run git push "$REMOTE" "$MAIN_BRANCH"
   run git push "$REMOTE" "$VERSION"
+  STAGE="pushed"
   done_ok "pushed branch + tag"
 }
 
@@ -317,7 +415,9 @@ create_gh_release() {
     warn "Skipping GitHub release step (--no-gh)"
     return
   fi
-  log "Create GitHub release + attach asset"
+  log "Create GitHub release + attach assets"
+  local asset="$DIST_DIR/$RELEASE_ASSET"
+  local checksum="$DIST_DIR/$CHECKSUM_FILE"
   local notes_url="$REPO_URL/blob/$VERSION/CHANGELOG.md"
   local body
   body="See [CHANGELOG.md]($notes_url) for the full notes.
@@ -326,22 +426,62 @@ create_gh_release() {
 \`\`\`bash
 curl -fsSLo lib/bashdep $REPO_URL/releases/download/$VERSION/$RELEASE_ASSET
 chmod +x lib/bashdep
-\`\`\`"
+\`\`\`
+
+Verify with the attached \`$CHECKSUM_FILE\`."
   if $DRY_RUN; then
-    plan "gh release create $VERSION --title 'Release $VERSION' --notes <generated> $RELEASE_ASSET"
+    plan "gh release create $VERSION --title 'Release $VERSION' --notes <generated> $asset $checksum"
     return
   fi
   gh release create "$VERSION" \
     --repo "$REPO_PATH" \
     --title "Release $VERSION" \
     --notes "$body" \
-    "$RELEASE_ASSET"
-  done_ok "GitHub release created with $RELEASE_ASSET attached"
+    "$asset" "$checksum"
+  done_ok "GitHub release created"
+
+  # Verify both assets actually attached (guards against a partial upload).
+  local attached
+  attached=$(gh release view "$VERSION" --repo "$REPO_PATH" \
+    --json assets --jq '.assets[].name' 2>/dev/null || true)
+  local name
+  for name in "$RELEASE_ASSET" "$CHECKSUM_FILE"; do
+    case $'\n'"$attached"$'\n' in
+      *$'\n'"$name"$'\n'*) ok "asset attached: $name" ;;
+      *) err "asset '$name' missing from release $VERSION"; exit 1 ;;
+    esac
+  done
 }
 
 # --- Main --------------------------------------------------------------------
 
+# On unexpected exit, undo work that is safe to undo. Before the commit we
+# own the file mutations and the dist/ dir, so revert them. After the commit
+# the state is on disk (and maybe pushed), so only advise — never rewrite
+# history automatically.
+cleanup() {
+  local code=$?
+  [[ $code -eq 0 ]] && return 0
+  $DRY_RUN && return 0
+  case $STAGE in
+    mutated)
+      warn "release failed after mutating files — reverting"
+      git checkout -- bashdep CHANGELOG.md 2>/dev/null || true
+      rm -rf "$DIST_DIR"
+      ;;
+    committed)
+      warn "release failed after commit/tag — undo with:"
+      warn "  git reset --hard HEAD~1 && git tag -d $VERSION"
+      ;;
+    pushed)
+      warn "release failed after push — the tag is on $REMOTE."
+      warn "  finish manually or delete the remote tag to retry."
+      ;;
+  esac
+}
+
 main() {
+  cd "$SCRIPT_DIR"
   parse_args "$@"
   preflight
 
@@ -350,14 +490,17 @@ main() {
   fi
 
   confirm
+  trap cleanup EXIT
 
   bump_version
   roll_changelog
   run_gates
+  build_asset
   commit_and_tag
   push
   create_gh_release
 
+  STAGE="done"
   log "Done."
   done_ok "Release $VERSION published."
   if ! $DRY_RUN; then
@@ -365,4 +508,8 @@ main() {
   fi
 }
 
-main "$@"
+# Run only when executed directly; sourcing (e.g. from tests) exposes the
+# functions without side effects.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/tests/unit/release_test.sh
+++ b/tests/unit/release_test.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# shellcheck disable=SC2155,SC2034
+#
+# Unit tests for release.sh. The script is sourced (guarded by its
+# BASH_SOURCE check) to exercise individual functions — main() never runs
+# and no release is ever cut. Functions that call `exit` on failure are
+# invoked inside a subshell so the exit does not kill the test runner.
+
+TEST_DIR=""
+
+function set_up() {
+  # Source once; release.sh declares readonly globals, so re-sourcing in the
+  # same process would error. The guard makes it idempotent.
+  if ! declare -f build_asset >/dev/null 2>&1; then
+    # shellcheck disable=SC1091
+    source "$(current_dir)/../../release.sh"
+  fi
+  # release.sh enables `set -euo pipefail` at source time; drop it so tests
+  # can assert on non-zero return codes normally.
+  set +e +u +o pipefail
+  DRY_RUN=false
+  REPO_ROOT="$(cd "$(current_dir)/../.." && pwd)"
+  TEST_DIR=$(mktemp -d)
+}
+
+function tear_down() {
+  if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+    rm -rf "$TEST_DIR"
+  fi
+}
+
+# --- bump_version_string -----------------------------------------------------
+
+function test_release_bump_version_major() {
+  assert_equals "1.0.0" "$(bump_version_string 0.4.2 major)"
+}
+
+function test_release_bump_version_minor() {
+  assert_equals "0.5.0" "$(bump_version_string 0.4.2 minor)"
+}
+
+function test_release_bump_version_patch() {
+  assert_equals "0.4.3" "$(bump_version_string 0.4.2 patch)"
+}
+
+function test_release_bump_version_minor_resets_patch() {
+  assert_equals "1.3.0" "$(bump_version_string 1.2.9 minor)"
+}
+
+# --- sha256_of ---------------------------------------------------------------
+
+function test_release_sha256_of_records_basename_not_path() {
+  printf 'payload\n' > "$TEST_DIR/asset"
+  local line
+  line=$(sha256_of "$TEST_DIR/asset")
+  assert_matches "^[0-9a-f]{64}[[:space:]]+asset$" "$line"
+}
+
+# --- unreleased_has_content --------------------------------------------------
+
+function test_release_unreleased_has_content_true_with_entry() {
+  printf '## [Unreleased]\n\n### Added\n- a thing\n\n## [0.1]\n' \
+    > "$TEST_DIR/CHANGELOG.md"
+  ( cd "$TEST_DIR" && unreleased_has_content )
+  assert_successful_code "$?"
+}
+
+function test_release_unreleased_has_content_false_when_only_headings() {
+  printf '## [Unreleased]\n\n### Added\n\n### Changed\n\n## [0.1]\n' \
+    > "$TEST_DIR/CHANGELOG.md"
+  ( cd "$TEST_DIR" && unreleased_has_content )
+  assert_general_error
+}
+
+# --- build_asset -------------------------------------------------------------
+
+function test_release_build_asset_produces_binary_and_checksum() {
+  cp "$REPO_ROOT/bashdep" "$TEST_DIR/bashdep"
+  ( cd "$TEST_DIR" && build_asset ) >/dev/null 2>&1
+
+  assert_file_exists "$TEST_DIR/dist/bashdep"
+  assert_file_exists "$TEST_DIR/dist/checksum"
+}
+
+function test_release_build_asset_binary_is_executable() {
+  cp "$REPO_ROOT/bashdep" "$TEST_DIR/bashdep"
+  ( cd "$TEST_DIR" && build_asset ) >/dev/null 2>&1
+  [[ -x "$TEST_DIR/dist/bashdep" ]]
+  assert_successful_code "$?"
+}
+
+function test_release_build_asset_checksum_matches_binary() {
+  cp "$REPO_ROOT/bashdep" "$TEST_DIR/bashdep"
+  ( cd "$TEST_DIR" && build_asset ) >/dev/null 2>&1
+
+  local stored expected
+  stored=$(cat "$TEST_DIR/dist/checksum")
+  expected=$(cd "$TEST_DIR" && sha256_of dist/bashdep)
+  assert_equals "$expected" "$stored"
+}
+
+function test_release_build_asset_fails_on_invalid_syntax() {
+  printf 'if [ ( broken\n' > "$TEST_DIR/bashdep"
+  ( cd "$TEST_DIR" && build_asset ) >/dev/null 2>&1
+  assert_general_error
+}
+
+function test_release_build_asset_dry_run_writes_nothing() {
+  cp "$REPO_ROOT/bashdep" "$TEST_DIR/bashdep"
+  ( cd "$TEST_DIR" && DRY_RUN=true && build_asset ) >/dev/null 2>&1
+
+  assert_file_not_exists "$TEST_DIR/dist/bashdep"
+  assert_file_not_exists "$TEST_DIR/dist/checksum"
+}


### PR DESCRIPTION
## Summary

Reworks `release.sh` to match bashunit's build-and-ship model: the release now produces a **built, checksummed asset** and uploads it, all in one executable — plus robustness fixes.

### Build & assets
- New `build_asset` step stages the version-bumped `bashdep` into `dist/`, syntax-checks it with `bash -n`, and writes a sha256 `checksum` (portable `shasum`/`sha256sum`).
- GitHub release uploads **both** `bashdep` and `checksum`, then verifies both assets actually attached (`gh release view --json assets`).
- `dist/` is git-ignored (build artifact, not source).

### Hardening (the "optimized" part)
- **Preflight tooling check**: `make`, `shellcheck`, `ec`, and a checksum tool are verified up front, so a missing gate tool fails *before* any file is mutated (soft-warns in `--dry-run`, which runs no gates).
- **Empty-`[Unreleased]` guard**: refuses to cut a release with no changelog content.
- **Cleanup trap**: on failure before the commit, file mutations and `dist/` are auto-reverted; after the commit it prints the exact recovery command instead of leaving a half-done state.
- **Source-safe**: `main` is guarded by a `BASH_SOURCE` check and `cd` moved into it, so the script can be sourced for unit testing with no side effects.

### Tests
- New `tests/unit/release_test.sh` (12 tests) sourcing the guarded script: bump math (major/minor/patch), checksum basename, empty-Unreleased detection, and `build_asset` (binary + checksum + checksum-matches-binary + syntax-failure + dry-run-writes-nothing).

## Test plan

- [x] Suite: 163 tests, 232 assertions, all green (was 151/218)
- [x] `make sa` clean (covers `release.sh`)
- [x] editorconfig checked manually (no >120 lines, no trailing ws/tabs)
- [x] Full `./release.sh 0.5.0 --dry-run --no-gh` preview walks every step
- [x] No network / no real release cut in tests — functions sourced and exercised in a scratch dir