### PR TITLE
fix(ci): call editorconfig-checker without the wrong -config flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ lint:
 ifndef LINTER_CHECKER
 	@printf "\e[1m\e[31m%s\e[0m\n" "Editorconfig not installed: Lint not performed!" && exit 1
 else
-	@ec -config .editorconfig && printf "\e[1m\e[32m%s\e[0m\n" "editorconfig-check: OK!"
+	@ec && printf "\e[1m\e[32m%s\e[0m\n" "editorconfig-check: OK!"
 endif
 
 deps:


### PR DESCRIPTION
## Summary

`make lint` ran `ec -config .editorconfig`, but editorconfig-checker's `-config` flag expects the checker's **own** JSON config (an `.ecrc`) — feeding it `.editorconfig` fails with `invalid character 'r' looking for beginning of value` on modern versions (3.x). The checker already auto-discovers `.editorconfig`; CI's linter job runs the binary **bare**. This aligns `make lint` with that.

Impact: `make lint` (and therefore the `release.sh` gate that calls it) was broken on any machine with a current editorconfig-checker. Found while cutting 0.5.0.

## Test plan

- [x] `make lint` → `editorconfig-check: OK!` (was Error 2)
- [x] Repo is genuinely clean under bare `ec` (0 violations)
- [x] `make test` / `make sa` still green
- [x] CI linter job unaffected (it never used the Makefile — runs `editorconfig-checker` directly)