### PR TITLE
chore: codebase quality cleanup (8-agent audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Changed
 
+- `bashdep::clean` now reports failed orphan removals to stderr and
+  returns the count of orphans it could not remove (capped at 255),
+  instead of always returning `0` and printing a `> removed orphan` line
+  even when the `rm` failed.
+
 ### Fixed
 
 - `bashdep::setup` and `bashdep::install` no longer leak their loop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ## [Unreleased]
 
-### Added
-
 ### Changed
 
 - `bashdep::clean` now reports failed orphan removals to stderr and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Fixed
 
+- `bashdep::setup` and `bashdep::install` no longer leak their loop
+  variables (`param`, `dep`) into the sourcing shell's global scope.
+
 ## [0.5.0] - 2026-07-20
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ ifndef STATIC_ANALYSIS_CHECKER
 	@printf "\e[1m\e[31m%s\e[0m\n" "Shellcheck not installed: Static analysis not performed!" && exit 1
 else
 	@find . -type f \( -name '*.sh' -o -name 'bashdep' -o -name 'pre-commit' \) \
-		-not -path './.git/*' -not -path './vendor/*' -not -path './lib/*' -not -path './local/*' \
+		-not -path './.git/*' -not -path './.claude/*' -not -path './vendor/*' \
+		-not -path './lib/*' -not -path './local/*' \
 		-exec shellcheck -e SC1091 -e SC2155 -C {} + \
 		&& printf "\e[1m\e[32m%s\e[0m\n" "ShellCheck: OK!"
 endif

--- a/bashdep
+++ b/bashdep
@@ -5,6 +5,7 @@ BASHDEP_DIR="lib"
 BASHDEP_DEV_DIR="lib/dev"
 BASHDEP_DEV_SUFFIX="@dev"
 BASHDEP_LOCK_FILE=".bashdep.lock"
+BASHDEP_DEP_FILE=".bashdep"
 BASHDEP_SILENT=false
 BASHDEP_FORCE=false
 BASHDEP_DRY_RUN=false
@@ -101,7 +102,7 @@ function bashdep::setup() {
 # in the current directory when no file is given. Returns the failure
 # count (capped at 255), or 1 if the file is unreadable.
 function bashdep::install_from() {
-  local file=${1:-.bashdep}
+  local file=${1:-$BASHDEP_DEP_FILE}
   if [[ ! -f "$file" ]]; then
     echo "Error: dependency file '$file' not found." >&2
     return 1
@@ -414,7 +415,7 @@ function bashdep::_is_orphan() {
 function bashdep::_lock_mktemp() {
   local lock_file=$1 lock_dir
   lock_dir=$(dirname "$lock_file")
-  mktemp "$lock_dir/.bashdep.lock.XXXXXX" || {
+  mktemp "$lock_dir/$BASHDEP_LOCK_FILE.XXXXXX" || {
     echo "Error: Could not create temp file for lockfile update." >&2
     return 1
   }
@@ -498,7 +499,7 @@ EOF
 # Returns: the underlying command's exit code; 1 on unknown command/option
 # or missing required arguments.
 function bashdep::main() {
-  local command="" dep_file=".bashdep"
+  local command="" dep_file="$BASHDEP_DEP_FILE"
   local args=() arg
 
   for arg in "$@"; do

--- a/bashdep
+++ b/bashdep
@@ -78,6 +78,7 @@ function bashdep::self_update() {
 # Example:
 #   bashdep::setup dir="vendor" dev-dir="src/dev" silent=true
 function bashdep::setup() {
+  local param
   for param in "$@"; do
     case $param in
       dir=*)       BASHDEP_DIR="${param#*=}"        ;;
@@ -248,6 +249,7 @@ function bashdep::list() {
 function bashdep::install() {
   local dependencies=("$@")
   local failures=0
+  local dep
 
   for dep in "${dependencies[@]}"; do
     bashdep::_classify_dep "$dep"

--- a/bashdep
+++ b/bashdep
@@ -163,7 +163,7 @@ function bashdep::uninstall() {
 function bashdep::clean() {
   local removed=0
   local self_name="${BASH_SOURCE[0]##*/}"
-  local dir lock_file file_path file_name seen=""
+  local dir lock_file file_path seen=""
   for dir in "$BASHDEP_DIR" "$BASHDEP_DEV_DIR"; do
     [[ -z "$dir" || ! -d "$dir" ]] && continue
     case ":$seen:" in *":$dir:"*) continue ;; esac
@@ -171,11 +171,7 @@ function bashdep::clean() {
     lock_file="$dir/$BASHDEP_LOCK_FILE"
     [[ -f "$lock_file" ]] || continue
     for file_path in "$dir"/*; do
-      [[ -f "$file_path" ]] || continue
-      file_name="${file_path##*/}"
-      [[ "$file_name" == "$BASHDEP_LOCK_FILE" ]] && continue
-      [[ "$file_name" == "$self_name" ]] && continue
-      [[ -n "$(bashdep::_lock_get "$lock_file" "$file_name")" ]] && continue
+      bashdep::_is_orphan "$file_path" "$self_name" "$lock_file" || continue
       if bashdep::is_dry_run; then
         bashdep::_log "[dry-run] Would remove orphan '$file_path'"
       else
@@ -196,7 +192,7 @@ function bashdep::clean() {
 function bashdep::doctor() {
   local issues=0
   local self_name="${BASH_SOURCE[0]##*/}"
-  local dir lock_file file_path file_name entry_name entry_url seen=""
+  local dir lock_file file_path entry_name entry_url seen=""
   for dir in "$BASHDEP_DIR" "$BASHDEP_DEV_DIR"; do
     [[ -z "$dir" || ! -d "$dir" ]] && continue
     case ":$seen:" in *":$dir:"*) continue ;; esac
@@ -215,11 +211,7 @@ function bashdep::doctor() {
       fi
     done < "$lock_file"
     for file_path in "$dir"/*; do
-      [[ -f "$file_path" ]] || continue
-      file_name="${file_path##*/}"
-      [[ "$file_name" == "$BASHDEP_LOCK_FILE" ]] && continue
-      [[ "$file_name" == "$self_name" ]] && continue
-      if [[ -z "$(bashdep::_lock_get "$lock_file" "$file_name")" ]]; then
+      if bashdep::_is_orphan "$file_path" "$self_name" "$lock_file"; then
         bashdep::_log "  orphan file '$file_path' (no lockfile entry)"
         issues=$((issues + 1))
       fi
@@ -402,23 +394,34 @@ function bashdep::_lock_get() {
   awk -F '\t' -v name="$file_name" '$1 == name { print $2; exit }' "$lock_file"
 }
 
-# Internal: drop the entry for $file_name from the lockfile. Removes the
-# lockfile entirely once it has no entries left. No-op when the lockfile
-# does not exist. Returns 1 if the rewrite cannot be persisted.
-function bashdep::_lock_remove() {
-  local lock_file=$1 file_name=$2
-  [[ -f "$lock_file" ]] || return 0
-  local lock_dir tmp
+# Internal: return 0 when $file_path is an orphan — a regular file that is
+# neither the lockfile nor the bashdep script itself ($2) and has no entry
+# in $lock_file ($3). Shared by clean and doctor.
+function bashdep::_is_orphan() {
+  local file_path=$1 self_name=$2 lock_file=$3
+  [[ -f "$file_path" ]] || return 1
+  local file_name="${file_path##*/}"
+  [[ "$file_name" == "$BASHDEP_LOCK_FILE" ]] && return 1
+  [[ "$file_name" == "$self_name" ]] && return 1
+  [[ -z "$(bashdep::_lock_get "$lock_file" "$file_name")" ]]
+}
+
+# Internal: create a temp file alongside the lockfile for an atomic
+# rewrite. Prints the temp path on stdout. Returns 1 if it cannot be
+# created.
+function bashdep::_lock_mktemp() {
+  local lock_file=$1 lock_dir
   lock_dir=$(dirname "$lock_file")
-  tmp=$(mktemp "$lock_dir/.bashdep.lock.XXXXXX") || {
+  mktemp "$lock_dir/.bashdep.lock.XXXXXX" || {
     echo "Error: Could not create temp file for lockfile update." >&2
     return 1
   }
-  awk -F '\t' -v name="$file_name" '$1 != name' "$lock_file" | LC_ALL=C sort > "$tmp"
-  if [[ ! -s "$tmp" ]]; then
-    rm -f "$tmp" "$lock_file"
-    return 0
-  fi
+}
+
+# Internal: atomically move a staged temp file onto the lockfile. Cleans
+# up the temp on failure. Returns 1 if the move fails.
+function bashdep::_lock_commit() {
+  local tmp=$1 lock_file=$2
   if ! mv "$tmp" "$lock_file"; then
     rm -f "$tmp"
     echo "Error: Could not write lockfile '$lock_file'." >&2
@@ -426,28 +429,33 @@ function bashdep::_lock_remove() {
   fi
 }
 
+# Internal: drop the entry for $file_name from the lockfile. Removes the
+# lockfile entirely once it has no entries left. No-op when the lockfile
+# does not exist. Returns 1 if the rewrite cannot be persisted.
+function bashdep::_lock_remove() {
+  local lock_file=$1 file_name=$2
+  [[ -f "$lock_file" ]] || return 0
+  local tmp
+  tmp=$(bashdep::_lock_mktemp "$lock_file") || return 1
+  awk -F '\t' -v name="$file_name" '$1 != name' "$lock_file" | LC_ALL=C sort > "$tmp"
+  if [[ ! -s "$tmp" ]]; then
+    rm -f "$tmp" "$lock_file"
+    return 0
+  fi
+  bashdep::_lock_commit "$tmp" "$lock_file"
+}
+
 # Internal: upsert filename → URL mapping in lockfile.
 # Returns 1 if the lockfile cannot be written.
 function bashdep::_lock_set() {
   local lock_file=$1 file_name=$2 url=$3
-  local lock_dir tmp
-
-  lock_dir=$(dirname "$lock_file")
-  tmp=$(mktemp "$lock_dir/.bashdep.lock.XXXXXX") || {
-    echo "Error: Could not create temp file for lockfile update." >&2
-    return 1
-  }
-
+  local tmp
+  tmp=$(bashdep::_lock_mktemp "$lock_file") || return 1
   {
     [[ -f "$lock_file" ]] && awk -F '\t' -v name="$file_name" '$1 != name' "$lock_file"
     printf '%s\t%s\n' "$file_name" "$url"
   } | LC_ALL=C sort > "$tmp"
-
-  if ! mv "$tmp" "$lock_file"; then
-    rm -f "$tmp"
-    echo "Error: Could not write lockfile '$lock_file'." >&2
-    return 1
-  fi
+  bashdep::_lock_commit "$tmp" "$lock_file"
 }
 
 # Print CLI usage.

--- a/bashdep
+++ b/bashdep
@@ -160,10 +160,10 @@ function bashdep::uninstall() {
 # bashdep script itself. Skips directories with no lockfile (a missing
 # lockfile is treated as 'don't manage this dir', not 'every file is an
 # orphan'). In dry-run mode, prints intended removals without touching
-# disk. Returns 0 always; failures from individual rm calls are not
-# propagated.
+# disk. Returns 0 when every orphan was removed, otherwise the number of
+# orphans that could not be removed (capped at 255).
 function bashdep::clean() {
-  local removed=0
+  local removed=0 failures=0
   local self_name="${BASH_SOURCE[0]##*/}"
   local dir lock_file file_path seen=""
   for dir in "$BASHDEP_DIR" "$BASHDEP_DEV_DIR"; do
@@ -176,14 +176,18 @@ function bashdep::clean() {
       bashdep::_is_orphan "$file_path" "$self_name" "$lock_file" || continue
       if bashdep::is_dry_run; then
         bashdep::_log "[dry-run] Would remove orphan '$file_path'"
-      else
-        rm -f "$file_path"
+        removed=$((removed + 1))
+      elif rm -f "$file_path"; then
         bashdep::_log "> removed orphan '$file_path'"
+        removed=$((removed + 1))
+      else
+        echo "Error: failed to remove orphan '$file_path'." >&2
+        failures=$((failures + 1))
       fi
-      removed=$((removed + 1))
     done
   done
   bashdep::_log "Cleaned $removed orphan(s)."
+  return $(( failures > 255 ? 255 : failures ))
 }
 
 # Check each managed directory for consistency. Reports two kinds of issues:

--- a/docs/api.md
+++ b/docs/api.md
@@ -103,7 +103,9 @@ dir is unmanaged".
 bashdep::clean
 ```
 
-Always returns 0. Honors dry-run mode.
+Returns 0 when every orphan was removed, otherwise the number of orphans
+that could not be removed (e.g. a permission error), capped at 255. A
+failed removal is reported to stderr. Honors dry-run mode.
 
 ## `bashdep::doctor`
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -61,6 +61,9 @@ both by default.
   is missing or unreadable.
 - `bashdep::setup` returns `1` on unknown params or non-boolean values
   for `silent` / `force`.
+- `bashdep::clean` returns the number of orphans it could not remove
+  (capped at 255), reporting each failed removal to stderr; `0` when all
+  orphans were removed.
 - `curl` failures print the exit code to stderr (e.g. `22` = HTTP error,
   `6` = DNS, `7` = connect refused).
 

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -270,6 +270,19 @@ function test_bashdep_set_bool_error_includes_label_and_value() {
   assert_contains "bogus"   "$err"
 }
 
+function test_bashdep_setup_does_not_leak_loop_variable() {
+  unset param
+  bashdep::setup dir="lib"
+  assert_empty "${param:-}"
+}
+
+function test_bashdep_install_does_not_leak_loop_variable() {
+  unset dep
+  BASHDEP_DRY_RUN=true
+  bashdep::install "https://example.com/foo.sh" >/dev/null
+  assert_empty "${dep:-}"
+}
+
 function test_bashdep_install_caps_failure_count_at_255() {
   mock bashdep::setup_directory "return 0"
   mock bashdep::download_url "return 1"

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -1027,6 +1027,32 @@ function test_bashdep_clean_handles_both_dirs() {
   assert_file_exists     "$BASHDEP_DEV_DIR/b"
 }
 
+function test_bashdep_clean_returns_failure_when_rm_fails() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" tracked https://example.com/tracked
+  touch "$TEST_DIR/orphan"
+  mock rm "return 1"
+
+  local rc=0
+  bashdep::clean >/dev/null 2>&1 || rc=$?
+  unmock rm
+
+  assert_equals 1 "$rc"
+}
+
+function test_bashdep_clean_reports_error_when_rm_fails() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" tracked https://example.com/tracked
+  touch "$TEST_DIR/orphan"
+  mock rm "return 1"
+
+  local err
+  err=$(bashdep::clean 2>&1 >/dev/null)
+  unmock rm
+
+  assert_contains "failed to remove orphan" "$err"
+}
+
 function test_bashdep_lock_remove_drops_entry() {
   local lock_file="$TEST_DIR/lock"
   printf 'aaa\thttps://example.com/aaa\nbbb\thttps://example.com/bbb\n' > "$lock_file"

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -373,6 +373,34 @@ function test_bashdep_should_skip_download_no_when_lockfile_missing() {
   assert_general_error
 }
 
+# _is_orphan predicate tests — shared by clean and doctor.
+
+function test_bashdep_is_orphan_true_when_file_has_no_lock_entry() {
+  _seed_lock "$TEST_DIR" tracked https://example.com/tracked
+  touch "$TEST_DIR/orphan"
+  bashdep::_is_orphan "$TEST_DIR/orphan" bashdep "$TEST_DIR/.bashdep.lock"
+  assert_successful_code "$?"
+}
+
+function test_bashdep_is_orphan_false_when_file_has_lock_entry() {
+  _seed_installed "$TEST_DIR" tracked https://example.com/tracked
+  bashdep::_is_orphan "$TEST_DIR/tracked" bashdep "$TEST_DIR/.bashdep.lock"
+  assert_general_error
+}
+
+function test_bashdep_is_orphan_false_for_lockfile_itself() {
+  _seed_installed "$TEST_DIR" tracked https://example.com/tracked
+  bashdep::_is_orphan "$TEST_DIR/.bashdep.lock" bashdep "$TEST_DIR/.bashdep.lock"
+  assert_general_error
+}
+
+function test_bashdep_is_orphan_false_for_self_name() {
+  _seed_lock "$TEST_DIR" tracked https://example.com/tracked
+  touch "$TEST_DIR/bashdep"
+  bashdep::_is_orphan "$TEST_DIR/bashdep" bashdep "$TEST_DIR/.bashdep.lock"
+  assert_general_error
+}
+
 # setup_directory tests.
 
 function test_bashdep_setup_directory() {


### PR DESCRIPTION
## Summary

Ran an 8-way code-quality audit (DRY, shared types/constants, unused code, circular deps, weak types, defensive programming, legacy code, comments). This repo is already in strong shape — **4 of 8 axes found nothing to change**; the other 4 yielded high-confidence, test-backed fixes. No public function was removed; the one behavioral change (`clean` return code) is documented.

### Changes landed

- **`ref: share lockfile-rewrite and orphan-check helpers`** (DRY) — extracted `_lock_mktemp`, `_lock_commit`, and `_is_orphan`; `_lock_set`/`_lock_remove` and `clean`/`doctor` now share them. +4 unit tests for `_is_orphan`. Behavior-identical.
- **`ref(setup): declare loop variables local`** (weak/loose handling) — `setup`'s `param` and `install`'s `dep` weren't `local`, leaking into the sourcing shell's globals (real bug for a sourced library). +2 regression tests.
- **`ref(lock): reference config globals`** (shared constants) — added `BASHDEP_DEP_FILE`; `install_from`/`main` and the lockfile temp templates now reference `$BASHDEP_LOCK_FILE`/`$BASHDEP_DEP_FILE` instead of duplicated literals.
- **`fix(clean): report and count failed orphan removals`** (defensive/error-hiding) — `clean` used to log `> removed orphan` and return `0` even when `rm` failed. Now reports to stderr and returns the failed-removal count (capped 255), consistent with `install`/`uninstall`/`doctor`. +2 tests; `docs/api.md`, `docs/behavior.md`, `CHANGELOG.md` updated. **Public return-semantics change.**
- **`ci(sa): exclude .claude worktrees`** — the `sa` target's `find` could recurse outside the project; excluded `.claude/` alongside vendor/lib/local.

### Axes that found nothing (verified, no changes)

- **Unused code** — every function has a caller or is documented public API; ShellCheck SC2034 clean.
- **Circular deps** — `bashdep`/`release.sh` source nothing; strict DAG, correct definition order. (madge is JS-only, N/A.)
- **Legacy/fallback** — no shims; the "re-download without lock entry" is natural idempotency, not migration code. Bash 3.2 compat constructs correctly preserved.
- **Comments/slop** — API-contract headers, justified shellcheck reasons, and "why" notes are all legitimate; no history-narration or stubs.

## Test plan

- [x] Suite: **171 tests, 240 assertions**, all green (was 163/232) — +8 tests across the 4 fixes
- [x] `make sa` (ShellCheck) clean
- [x] `make lint` (editorconfig) clean
- [x] No public function removed; the single behavioral change (`clean`) is documented in api.md + behavior.md + CHANGELOG
- [x] Integration conflicts (lock helpers, `clean`) resolved by hand and re-verified