### PR TITLE
feat(install): wget fallback when curl is unavailable

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -31,9 +31,10 @@ See `.claude/rules/bash-style.md` (auto-loaded when editing `bashdep` or any
 
 ### Zero Runtime Dependencies
 
-Library code may only call: `curl`, `awk`, `mktemp`, `mkdir`, `rm`, `cp`,
-`mv`, `printf`, `cat`, `grep`, `sort`, `tr`, `dirname`, `basename`, plus
-shell builtins. **No** `jq`, `python`, `node`, etc. at runtime.
+Library code may only call: `curl` (or `wget` as a fallback), `awk`,
+`mktemp`, `mkdir`, `rm`, `cp`, `mv`, `printf`, `cat`, `grep`, `sort`,
+`tr`, `dirname`, `basename`, plus shell builtins. **No** `jq`, `python`,
+`node`, etc. at runtime.
 
 ### Quality Standards
 
@@ -161,7 +162,7 @@ in each rule file).
 ## Guardrails
 
 ### Never:
-- Add a runtime dependency beyond `curl` / `awk` / `mktemp` / POSIX builtins
+- Add a runtime dependency beyond `curl` / `wget` / `awk` / `mktemp` / POSIX builtins
 - Break Bash 3.2+ compatibility (test on macOS default bash mentally)
 - Change public function signatures without updating `docs/api.md` and `CHANGELOG.md`
 - Skip `make pre_commit/run` before pushing

--- a/.claude/rules/bash-style.md
+++ b/.claude/rules/bash-style.md
@@ -27,10 +27,11 @@ When in doubt: assume macOS default bash and avoid the feature.
 
 ## Runtime Dependency Policy
 
-Library code in `bashdep` may only call: `curl`, `awk`, `mktemp`, `mkdir`,
-`rm`, `cp`, `mv`, `printf`, `cat`, `grep`, `sort`, `tr`, `dirname`,
-`basename`, `stat`, plus shell builtins. **Do not** introduce `jq`,
-`python`, `node`, `xargs --max-args`, GNU-only flags, etc.
+Library code in `bashdep` may only call: `curl` (or `wget` as a
+fallback), `awk`, `mktemp`, `mkdir`, `rm`, `cp`, `mv`, `printf`, `cat`,
+`grep`, `sort`, `tr`, `dirname`, `basename`, `stat`, plus shell builtins.
+**Do not** introduce `jq`, `python`, `node`, `xargs --max-args`,
+GNU-only flags, etc.
 
 If a feature seems to need a new dependency, propose it in an issue first.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ## [Unreleased]
 
+### Added
+
+- Downloads fall back to `wget` when `curl` is not installed (curl is
+  still preferred). Fails with a clear error only when neither is
+  available. Closes #1.
+
 ### Changed
 
 - `bashdep::clean` now reports failed orphan removals to stderr and

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 Minimal, zero-dependency **bash dependency manager**. Declare URLs;
 bashdep downloads them into `lib/` and keeps installs idempotent via a
-per-directory `.bashdep.lock`. No registry, no runtime — just `curl`.
+per-directory `.bashdep.lock`. No registry, no runtime — just `curl`
+(or `wget`).
 
 ## Quick start
 

--- a/bashdep
+++ b/bashdep
@@ -47,7 +47,7 @@ function bashdep::self_update() {
   }
 
   bashdep::_log "Updating '$target' from '$url'..."
-  if ! curl -fsSL "$url" -o "$tmp"; then
+  if ! bashdep::_download "$url" "$tmp"; then
     rm -f "$tmp"
     echo "Error: failed to download bashdep from '$url'" >&2
     return 1
@@ -330,10 +330,10 @@ function bashdep::download_url() {
   bashdep::_vlog "  url: $url"
 
   local rc
-  curl -fsSL "$url" -o "$destination_file"
+  bashdep::_download "$url" "$destination_file"
   rc=$?
   if [[ $rc -ne 0 ]]; then
-    echo "Error: curl exit $rc — failed to install $file_name from $url" >&2
+    echo "Error: download failed (exit $rc) — could not install $file_name from $url" >&2
     return 1
   fi
 
@@ -341,6 +341,25 @@ function bashdep::download_url() {
   chmod +x "$destination_file"
   bashdep::_lock_set "$lock_file" "$file_name" "$url" || return 1
   bashdep::_vlog "  lockfile: $lock_file"
+}
+
+# Internal: capability checks for the supported downloaders.
+function bashdep::_has_curl() { command -v curl >/dev/null 2>&1; }
+function bashdep::_has_wget() { command -v wget >/dev/null 2>&1; }
+
+# Internal: download $1 (url) into $2 (output path). Prefers curl and falls
+# back to wget when curl is not installed. Returns the downloader's own exit
+# code, or 127 when neither curl nor wget is available.
+function bashdep::_download() {
+  local url=$1 output=$2
+  if bashdep::_has_curl; then
+    curl -fsSL "$url" -o "$output"
+  elif bashdep::_has_wget; then
+    wget -qO "$output" "$url"
+  else
+    echo "Error: neither curl nor wget is installed." >&2
+    return 127
+  fi
 }
 
 function bashdep::is_silent() {

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -64,8 +64,10 @@ both by default.
 - `bashdep::clean` returns the number of orphans it could not remove
   (capped at 255), reporting each failed removal to stderr; `0` when all
   orphans were removed.
-- `curl` failures print the exit code to stderr (e.g. `22` = HTTP error,
-  `6` = DNS, `7` = connect refused).
+- Downloads use `curl` when available and fall back to `wget`; if neither
+  is installed the download fails with exit `127`.
+- Download failures print the downloader's exit code to stderr (e.g. curl
+  `22` = HTTP error, `6` = DNS, `7` = connect refused).
 
 Pair with `set -euo pipefail` and `|| exit $?` to fail fast:
 

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -621,6 +621,44 @@ function test_bashdep_download_url_returns_zero_on_success() {
   assert_successful_code "$?"
 }
 
+function test_bashdep_download_prefers_curl_when_available() {
+  mock bashdep::_has_curl "return 0"
+  mock bashdep::_has_wget "return 0"
+  # shellcheck disable=SC2016
+  mock curl 'touch "$4.curl"'
+  # shellcheck disable=SC2016
+  mock wget 'touch "$2.wget"'
+  bashdep::_download "https://example.com/x" "$TEST_DIR/out"
+  assert_file_exists "$TEST_DIR/out.curl"
+  assert_file_not_exists "$TEST_DIR/out.wget"
+}
+
+function test_bashdep_download_uses_wget_when_curl_absent() {
+  mock bashdep::_has_curl "return 1"
+  # shellcheck disable=SC2016
+  mock wget 'touch "$2"'
+  bashdep::_download "https://example.com/tool" "$TEST_DIR/out"
+  assert_file_exists "$TEST_DIR/out"
+}
+
+function test_bashdep_download_errors_when_no_downloader() {
+  mock bashdep::_has_curl "return 1"
+  mock bashdep::_has_wget "return 1"
+  local err rc
+  err=$(bashdep::_download "https://example.com/x" "$TEST_DIR/out" 2>&1); rc=$?
+  assert_equals 127 "$rc"
+  assert_contains "neither curl nor wget" "$err"
+}
+
+function test_bashdep_download_url_works_with_wget_fallback() {
+  mock bashdep::_has_curl "return 1"
+  # shellcheck disable=SC2016
+  mock wget 'touch "$2"'
+  bashdep::download_url "https://example.com/tool" "$TEST_DIR" >/dev/null
+  assert_file_exists "$TEST_DIR/tool"
+  assert_file_exists "$TEST_DIR/.bashdep.lock"
+}
+
 function test_bashdep_download_url_returns_zero_when_verbose_off() {
   # shellcheck disable=SC2016
   mock curl 'touch "$4"'
@@ -1404,7 +1442,7 @@ function test_bashdep_cli_install_curl_failure_exits_nonzero() {
   stderr=$(PATH="$TEST_DIR/bin:$PATH" bash "$BASHDEP_BIN" install \
     --dir="$TEST_DIR" "https://example.com/tool" 2>&1 >/dev/null)
   assert_general_error
-  assert_contains "curl exit 7" "$stderr"
+  assert_contains "exit 7" "$stderr"
 }
 
 # Positional-argument accumulation: the first non-flag token is the


### PR DESCRIPTION
Closes #1

## Summary

Downloads now prefer `curl` and **fall back to `wget`** when curl isn't installed, failing with a clear error only when neither is available. Mirrors bashunit's approach.

- New private helpers: `bashdep::_has_curl`, `bashdep::_has_wget`, and `bashdep::_download <url> <output>` (prefers curl, falls back to wget, returns `127` when neither exists).
- Both download sites — `download_url` and `self_update` — routed through `_download`. The `download_url` error message is now downloader-agnostic (`download failed (exit N)`).
- Runtime-dependency policy updated (`.claude/CLAUDE.md`, `.claude/rules/bash-style.md`) to allow `wget` as a sanctioned fallback — this issue is the "propose a new dep first" approval.
- Docs: `docs/behavior.md`, `README.md`, `CHANGELOG.md` (Added).

## Test plan

- [x] Suite: **175 tests, 247 assertions**, green (was 171/240) — +4 tests: curl preferred, wget fallback, neither-installed → 127, and `download_url` end-to-end via wget
- [x] Existing curl mocks unchanged (arg order preserved through `_download`)
- [x] `make sa` + `make lint` clean
- [x] Bash 3.2 compatible