### PR TITLE
ci(perf): parallel tests + bashunit cache + fewer subprocess forks

### DIFF
--- a/.env
+++ b/.env
@@ -2,3 +2,4 @@
 BASHUNIT_DEFAULT_PATH="tests"
 BASHUNIT_LOAD_FILE="tests/bootstrap.sh"
 BASHUNIT_DEV_LOG=local/out.log
+BASHUNIT_PARALLEL_RUN=true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: "Cache bashunit"
+        uses: actions/cache@v4
+        with:
+          path: lib
+          key: bashunit-${{ runner.os }}-${{ hashFiles('install-dependencies.sh') }}
+
       - name: "Install bashunit"
         run: bash install-dependencies.sh
 

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -1268,32 +1268,31 @@ function test_bashdep_cli_version_prints_version() {
   assert_equals "$BASHDEP_VERSION" "$output"
 }
 
+# Pure-dispatch CLI checks call bashdep::main in-process (bashdep is sourced
+# in set_up) — no subprocess needed. The executable entrypoint itself is
+# still smoke-tested by the version/e2e/sourcing-guard tests below.
 function test_bashdep_cli_help_prints_usage() {
-  local output
-  output=$(bash "$BASHDEP_BIN" --help)
-  assert_contains "Usage:" "$output"
+  assert_contains "Usage:" "$(bashdep::main --help)"
 }
 
 function test_bashdep_cli_help_command_prints_usage() {
-  local output
-  output=$(bash "$BASHDEP_BIN" help)
-  assert_contains "Usage:" "$output"
+  assert_contains "Usage:" "$(bashdep::main help)"
 }
 
 function test_bashdep_cli_no_args_prints_usage_and_fails() {
-  bash "$BASHDEP_BIN" >/dev/null 2>&1
+  bashdep::main >/dev/null 2>&1
   assert_general_error
 }
 
 function test_bashdep_cli_unknown_command_fails() {
   local stderr
-  stderr=$(bash "$BASHDEP_BIN" bogus 2>&1 >/dev/null)
+  stderr=$(bashdep::main bogus 2>&1 >/dev/null)
   assert_contains "Unknown command" "$stderr"
 }
 
 function test_bashdep_cli_unknown_option_fails() {
   local stderr
-  stderr=$(bash "$BASHDEP_BIN" install --bogus 2>&1 >/dev/null)
+  stderr=$(bashdep::main install --bogus 2>&1 >/dev/null)
   assert_contains "Unknown option" "$stderr"
 }
 
@@ -1377,9 +1376,7 @@ function test_bashdep_sourcing_does_not_invoke_cli() {
 }
 
 function test_bashdep_cli_short_help_flag_prints_usage() {
-  local output
-  output=$(bash "$BASHDEP_BIN" -h)
-  assert_contains "Usage:" "$output"
+  assert_contains "Usage:" "$(bashdep::main -h)"
 }
 
 function test_bashdep_cli_force_flag_bypasses_skip() {


### PR DESCRIPTION
Closes #28, closes #29. Grouped by boundary (CI + test-runner config).

- **#28** Enable bashunit `--parallel` via `.env` (`BASHUNIT_PARALLEL_RUN=true`) — bashunit reads `.env` for both local and CI. Verified stable (175/247) across repeated runs. Also trimmed six pure-dispatch CLI tests (help/no-args/unknown-command/unknown-option) from `bash $BASHDEP_BIN` subprocesses to in-process `bashdep::main` calls (bashdep is already sourced in `set_up`); the executable entrypoint stays covered by the version smoke test, the PATH-stubbed install e2e tests, and the sourcing-guard test.
- **#29** Add `actions/cache@v4` for `lib/` keyed on `hashFiles('install-dependencies.sh')` so warm CI runs skip the bashunit download; cache key rotates when the pinned version changes.

## Test plan
- [x] Suite green and stable in parallel: 175 tests / 247 assertions, 2x runs
- [x] `make sa` + `make lint` clean
- [x] Subprocess CLI tests 28 → 22; converted ones assert identical behavior in-process