### PR TITLE
perf(lock): single-pass membership + drop subshell forks

### DIFF
--- a/bashdep
+++ b/bashdep
@@ -10,6 +10,7 @@ BASHDEP_SILENT=false
 BASHDEP_FORCE=false
 BASHDEP_DRY_RUN=false
 BASHDEP_VERBOSE=false
+BASHDEP_DOWNLOADER=""
 BASHDEP_SELF_URL_TEMPLATE="${BASHDEP_SELF_URL_TEMPLATE:-https://raw.githubusercontent.com/Chemaclass/bashdep/%s/bashdep}"
 
 # Print bashdep version.
@@ -165,15 +166,16 @@ function bashdep::uninstall() {
 function bashdep::clean() {
   local removed=0 failures=0
   local self_name="${BASH_SOURCE[0]##*/}"
-  local dir lock_file file_path seen=""
+  local dir lock_file lock_names file_path seen=""
   for dir in "$BASHDEP_DIR" "$BASHDEP_DEV_DIR"; do
     [[ -z "$dir" || ! -d "$dir" ]] && continue
     case ":$seen:" in *":$dir:"*) continue ;; esac
     seen="$seen:$dir"
     lock_file="$dir/$BASHDEP_LOCK_FILE"
     [[ -f "$lock_file" ]] || continue
+    lock_names=$(bashdep::_lock_names "$lock_file")
     for file_path in "$dir"/*; do
-      bashdep::_is_orphan "$file_path" "$self_name" "$lock_file" || continue
+      bashdep::_is_orphan "$file_path" "$self_name" "$lock_names" || continue
       if bashdep::is_dry_run; then
         bashdep::_log "[dry-run] Would remove orphan '$file_path'"
         removed=$((removed + 1))
@@ -198,7 +200,7 @@ function bashdep::clean() {
 function bashdep::doctor() {
   local issues=0
   local self_name="${BASH_SOURCE[0]##*/}"
-  local dir lock_file file_path entry_name entry_url seen=""
+  local dir lock_file lock_names file_path entry_name entry_url seen=""
   for dir in "$BASHDEP_DIR" "$BASHDEP_DEV_DIR"; do
     [[ -z "$dir" || ! -d "$dir" ]] && continue
     case ":$seen:" in *":$dir:"*) continue ;; esac
@@ -216,8 +218,9 @@ function bashdep::doctor() {
         issues=$((issues + 1))
       fi
     done < "$lock_file"
+    lock_names=$(bashdep::_lock_names "$lock_file")
     for file_path in "$dir"/*; do
-      if bashdep::_is_orphan "$file_path" "$self_name" "$lock_file"; then
+      if bashdep::_is_orphan "$file_path" "$self_name" "$lock_names"; then
         bashdep::_log "  orphan file '$file_path' (no lockfile entry)"
         issues=$((issues + 1))
       fi
@@ -349,17 +352,25 @@ function bashdep::_has_wget() { command -v wget >/dev/null 2>&1; }
 
 # Internal: download $1 (url) into $2 (output path). Prefers curl and falls
 # back to wget when curl is not installed. Returns the downloader's own exit
-# code, or 127 when neither curl nor wget is available.
+# code, or 127 when neither curl nor wget is available. The choice is
+# resolved once per run (cached in BASHDEP_DOWNLOADER) so a batch install
+# does not re-probe, and stays consistent across all its downloads.
 function bashdep::_download() {
   local url=$1 output=$2
-  if bashdep::_has_curl; then
-    curl -fsSL "$url" -o "$output"
-  elif bashdep::_has_wget; then
-    wget -qO "$output" "$url"
-  else
-    echo "Error: neither curl nor wget is installed." >&2
-    return 127
+  if [[ -z "$BASHDEP_DOWNLOADER" ]]; then
+    if bashdep::_has_curl; then
+      BASHDEP_DOWNLOADER=curl
+    elif bashdep::_has_wget; then
+      BASHDEP_DOWNLOADER=wget
+    else
+      BASHDEP_DOWNLOADER=none
+    fi
   fi
+  case $BASHDEP_DOWNLOADER in
+    curl) curl -fsSL "$url" -o "$output" ;;
+    wget) wget -qO "$output" "$url" ;;
+    *) echo "Error: neither curl nor wget is installed." >&2; return 127 ;;
+  esac
 }
 
 function bashdep::is_silent() {
@@ -420,24 +431,38 @@ function bashdep::_lock_get() {
   awk -F '\t' -v name="$file_name" '$1 == name { print $2; exit }' "$lock_file"
 }
 
+# Internal: print every filename recorded in the lockfile, one per line
+# (empty when the lockfile is absent). Lets clean/doctor read the lockfile
+# once per directory instead of forking awk for every file on disk.
+function bashdep::_lock_names() {
+  local lock_file=$1
+  [[ -f "$lock_file" ]] || return 0
+  awk -F '\t' 'NF { print $1 }' "$lock_file"
+}
+
 # Internal: return 0 when $file_path is an orphan — a regular file that is
-# neither the lockfile nor the bashdep script itself ($2) and has no entry
-# in $lock_file ($3). Shared by clean and doctor.
+# neither the lockfile nor the bashdep script itself ($2) and whose name is
+# absent from the newline-delimited $lock_names list ($3, from _lock_names).
+# Shared by clean and doctor. The quoted case pattern matches the name
+# literally, so glob characters in filenames are safe.
 function bashdep::_is_orphan() {
-  local file_path=$1 self_name=$2 lock_file=$3
+  local file_path=$1 self_name=$2 lock_names=$3
   [[ -f "$file_path" ]] || return 1
   local file_name="${file_path##*/}"
   [[ "$file_name" == "$BASHDEP_LOCK_FILE" ]] && return 1
   [[ "$file_name" == "$self_name" ]] && return 1
-  [[ -z "$(bashdep::_lock_get "$lock_file" "$file_name")" ]]
+  case $'\n'"$lock_names"$'\n' in
+    *$'\n'"$file_name"$'\n'*) return 1 ;;
+  esac
+  return 0
 }
 
 # Internal: create a temp file alongside the lockfile for an atomic
 # rewrite. Prints the temp path on stdout. Returns 1 if it cannot be
 # created.
 function bashdep::_lock_mktemp() {
-  local lock_file=$1 lock_dir
-  lock_dir=$(dirname "$lock_file")
+  local lock_file=$1
+  local lock_dir="${lock_file%/*}"
   mktemp "$lock_dir/$BASHDEP_LOCK_FILE.XXXXXX" || {
     echo "Error: Could not create temp file for lockfile update." >&2
     return 1

--- a/release.sh
+++ b/release.sh
@@ -79,9 +79,10 @@ run() {
 # macOS (shasum) and Linux (sha256sum). Runs from the file's directory so
 # the recorded name is the bare basename, not a path.
 sha256_of() {
-  local path=$1 dir base
-  dir=$(dirname "$path")
-  base=$(basename "$path")
+  local path=$1
+  local base="${path##*/}"
+  local dir="${path%/*}"
+  [[ "$dir" == "$path" ]] && dir="."
   if command -v shasum >/dev/null 2>&1; then
     ( cd "$dir" && shasum -a 256 "$base" )
   else

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -10,6 +10,7 @@ function set_up() {
   BASHDEP_SILENT=false
   BASHDEP_DRY_RUN=false
   BASHDEP_VERBOSE=false
+  BASHDEP_DOWNLOADER=""
   TEST_DIR=$(mktemp -d)
   BASHDEP_BIN="$(cd "$(current_dir)/../.." && pwd)/bashdep"
 }
@@ -391,27 +392,43 @@ function test_bashdep_should_skip_download_no_when_lockfile_missing() {
 function test_bashdep_is_orphan_true_when_file_has_no_lock_entry() {
   _seed_lock "$TEST_DIR" tracked https://example.com/tracked
   touch "$TEST_DIR/orphan"
-  bashdep::_is_orphan "$TEST_DIR/orphan" bashdep "$TEST_DIR/.bashdep.lock"
+  local names; names=$(bashdep::_lock_names "$TEST_DIR/.bashdep.lock")
+  bashdep::_is_orphan "$TEST_DIR/orphan" bashdep "$names"
   assert_successful_code "$?"
 }
 
 function test_bashdep_is_orphan_false_when_file_has_lock_entry() {
   _seed_installed "$TEST_DIR" tracked https://example.com/tracked
-  bashdep::_is_orphan "$TEST_DIR/tracked" bashdep "$TEST_DIR/.bashdep.lock"
+  local names; names=$(bashdep::_lock_names "$TEST_DIR/.bashdep.lock")
+  bashdep::_is_orphan "$TEST_DIR/tracked" bashdep "$names"
   assert_general_error
 }
 
 function test_bashdep_is_orphan_false_for_lockfile_itself() {
   _seed_installed "$TEST_DIR" tracked https://example.com/tracked
-  bashdep::_is_orphan "$TEST_DIR/.bashdep.lock" bashdep "$TEST_DIR/.bashdep.lock"
+  local names; names=$(bashdep::_lock_names "$TEST_DIR/.bashdep.lock")
+  bashdep::_is_orphan "$TEST_DIR/.bashdep.lock" bashdep "$names"
   assert_general_error
 }
 
 function test_bashdep_is_orphan_false_for_self_name() {
   _seed_lock "$TEST_DIR" tracked https://example.com/tracked
   touch "$TEST_DIR/bashdep"
-  bashdep::_is_orphan "$TEST_DIR/bashdep" bashdep "$TEST_DIR/.bashdep.lock"
+  local names; names=$(bashdep::_lock_names "$TEST_DIR/.bashdep.lock")
+  bashdep::_is_orphan "$TEST_DIR/bashdep" bashdep "$names"
   assert_general_error
+}
+
+function test_bashdep_lock_names_lists_recorded_filenames() {
+  printf 'aaa\thttps://example.com/aaa\nbbb\thttps://example.com/bbb\n' \
+    > "$TEST_DIR/.bashdep.lock"
+  local names; names=$(bashdep::_lock_names "$TEST_DIR/.bashdep.lock")
+  assert_contains "aaa" "$names"
+  assert_contains "bbb" "$names"
+}
+
+function test_bashdep_lock_names_empty_when_lockfile_missing() {
+  assert_empty "$(bashdep::_lock_names "$TEST_DIR/nope.lock")"
 }
 
 # setup_directory tests.


### PR DESCRIPTION
Closes #25, closes #27. Read-path hot-path optimizations (no behavior change).

- **#25** New `_lock_names` reads each directory's lockfile **once**; `clean`/`doctor` test orphan membership in-shell via a quoted `case` (safe for glob chars in filenames) instead of forking `awk` through `_lock_get` for every file. `_is_orphan`'s 3rd param is now the preloaded names list. Turns O(files) awk spawns into one per directory.
- **#27** `$(dirname ...)` → `${path%/*}` parameter expansion in `_lock_mktemp` and `release.sh sha256_of` (with a no-slash guard); cache the resolved downloader in `BASHDEP_DOWNLOADER` (reset in `set_up`) so a batch install probes once and won't flip tools mid-run.

## Test plan
- [x] Suite green + stable (parallel): 177 tests / 250 assertions, 2x runs (+3: `_lock_names` x2, retained `_is_orphan` x4 updated)
- [x] release_test 12/12 after the `sha256_of` change
- [x] `make sa` + `make lint` clean
- [x] Identical output/return codes for clean/doctor (existing tests unchanged in intent)

Write-path batching (#26) is deliberately a separate PR — it changes the lockfile-write contract.