### PR TITLE
perf(lock): batch lockfile writes across an install

### DIFF
--- a/bashdep
+++ b/bashdep
@@ -11,6 +11,8 @@ BASHDEP_FORCE=false
 BASHDEP_DRY_RUN=false
 BASHDEP_VERBOSE=false
 BASHDEP_DOWNLOADER=""
+BASHDEP_LOCK_DEFER=false
+BASHDEP_LOCK_PENDING=()
 BASHDEP_SELF_URL_TEMPLATE="${BASHDEP_SELF_URL_TEMPLATE:-https://raw.githubusercontent.com/Chemaclass/bashdep/%s/bashdep}"
 
 # Print bashdep version.
@@ -259,11 +261,19 @@ function bashdep::install() {
   local failures=0
   local dep
 
+  # Defer lockfile writes: each download records its entry in
+  # BASHDEP_LOCK_PENDING and we rewrite each destination lockfile once at
+  # the end, instead of re-sorting the whole file on every dependency.
+  BASHDEP_LOCK_DEFER=true
+  BASHDEP_LOCK_PENDING=()
   for dep in "${dependencies[@]}"; do
     bashdep::_classify_dep "$dep"
     bashdep::setup_directory "$BASHDEP_DEP_DIR" || { failures=$((failures + 1)); continue; }
     bashdep::download_url "$BASHDEP_DEP_URL" "$BASHDEP_DEP_DIR" || failures=$((failures + 1))
   done
+  BASHDEP_LOCK_DEFER=false
+  bashdep::_lock_flush || failures=$((failures + 1))
+  BASHDEP_LOCK_PENDING=()
 
   return $(( failures > 255 ? 255 : failures ))
 }
@@ -342,7 +352,11 @@ function bashdep::download_url() {
 
   bashdep::_log "> $file_name installed successfully in '$destination_dir'"
   chmod +x "$destination_file"
-  bashdep::_lock_set "$lock_file" "$file_name" "$url" || return 1
+  if [[ "$BASHDEP_LOCK_DEFER" == true ]]; then
+    BASHDEP_LOCK_PENDING+=("$lock_file"$'\t'"$file_name"$'\t'"$url")
+  else
+    bashdep::_lock_set "$lock_file" "$file_name" "$url" || return 1
+  fi
   bashdep::_vlog "  lockfile: $lock_file"
 }
 
@@ -507,6 +521,36 @@ function bashdep::_lock_set() {
     printf '%s\t%s\n' "$file_name" "$url"
   } | LC_ALL=C sort > "$tmp"
   bashdep::_lock_commit "$tmp" "$lock_file"
+}
+
+# Internal: write every pending lockfile entry collected during a deferred
+# install, one rewrite per destination lockfile. No-op when nothing is
+# pending. Returns 1 if any lockfile cannot be written.
+function bashdep::_lock_flush() {
+  local entry lock_file seen=""
+  for entry in ${BASHDEP_LOCK_PENDING[@]+"${BASHDEP_LOCK_PENDING[@]}"}; do
+    lock_file="${entry%%$'\t'*}"
+    case ":$seen:" in *":$lock_file:"*) continue ;; esac
+    seen="$seen:$lock_file"
+    bashdep::_lock_flush_one "$lock_file" || return 1
+  done
+}
+
+# Internal: rewrite a single lockfile from its existing entries plus all
+# pending entries targeting it. A single awk keeps the last value per
+# filename (pending entries stream after the existing file, so they win),
+# then one sort orders the result. Returns 1 on write failure.
+function bashdep::_lock_flush_one() {
+  local target=$1 entry tmp
+  tmp=$(bashdep::_lock_mktemp "$target") || return 1
+  {
+    [[ -f "$target" ]] && cat "$target"
+    for entry in ${BASHDEP_LOCK_PENDING[@]+"${BASHDEP_LOCK_PENDING[@]}"}; do
+      [[ "${entry%%$'\t'*}" == "$target" ]] && printf '%s\n' "${entry#*$'\t'}"
+    done
+  } | awk -F '\t' 'NF >= 2 { keep[$1] = $0 } END { for (k in keep) print keep[k] }' \
+    | LC_ALL=C sort > "$tmp"
+  bashdep::_lock_commit "$tmp" "$target"
 }
 
 # Print CLI usage.

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -11,6 +11,8 @@ function set_up() {
   BASHDEP_DRY_RUN=false
   BASHDEP_VERBOSE=false
   BASHDEP_DOWNLOADER=""
+  BASHDEP_LOCK_DEFER=false
+  BASHDEP_LOCK_PENDING=()
   TEST_DIR=$(mktemp -d)
   BASHDEP_BIN="$(cd "$(current_dir)/../.." && pwd)/bashdep"
 }
@@ -765,6 +767,50 @@ function test_bashdep_install_lockfile_contains_all_deps() {
   lock=$(cat "$TEST_DIR/.bashdep.lock")
   assert_contains "aaa" "$lock"
   assert_contains "bbb" "$lock"
+}
+
+function test_bashdep_install_batch_keeps_lockfile_sorted() {
+  # shellcheck disable=SC2016
+  mock curl 'touch "$4"'
+  BASHDEP_DIR="$TEST_DIR"
+  bashdep::install \
+    "https://example.com/bbb" \
+    "https://example.com/aaa" >/dev/null
+  local lock; lock=$(cat "$TEST_DIR/.bashdep.lock")
+  assert_equals "aaa	https://example.com/aaa
+bbb	https://example.com/bbb" "$lock"
+}
+
+function test_bashdep_install_batch_last_write_wins_for_same_name() {
+  # shellcheck disable=SC2016
+  mock curl 'touch "$4"'
+  BASHDEP_DIR="$TEST_DIR"
+  bashdep::install \
+    "https://a.example.com/tool" \
+    "https://b.example.com/tool" >/dev/null
+  local lock; lock=$(cat "$TEST_DIR/.bashdep.lock")
+  assert_equals "1" "$(printf '%s\n' "$lock" | grep -c 'tool')"
+  assert_contains "b.example.com/tool" "$lock"
+}
+
+function test_bashdep_install_batch_preserves_existing_entry() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" existing https://example.com/existing
+  # shellcheck disable=SC2016
+  mock curl 'touch "$4"'
+  bashdep::install "https://example.com/new" >/dev/null
+  local lock; lock=$(cat "$TEST_DIR/.bashdep.lock")
+  assert_contains "existing" "$lock"
+  assert_contains "new" "$lock"
+}
+
+function test_bashdep_install_batch_noop_when_all_skipped() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" tool https://example.com/tool
+  mock curl "echo SHOULD_NOT_RUN"
+  local out; out=$(bashdep::install "https://example.com/tool")
+  assert_not_contains "SHOULD_NOT_RUN" "$out"
+  assert_contains "tool" "$(cat "$TEST_DIR/.bashdep.lock")"
 }
 
 function test_bashdep_install_from_defaults_to_bashdep_file() {


### PR DESCRIPTION
Closes #26. Write-path optimization, kept as its own PR since it changes when the lockfile is written.

- `install` sets `BASHDEP_LOCK_DEFER=true`; each download records `lock_file\tname\turl` in `BASHDEP_LOCK_PENDING` instead of calling `_lock_set` inline.
- After the loop, `_lock_flush` rewrites **each destination lockfile once**: existing entries + this dir's pending entries stream through a single `awk` that keeps the last value per filename (pending after existing ⇒ overwrite wins; later duplicates win), then one `LC_ALL=C sort`.
- N deps into one dir: **1 rewrite** instead of N. Direct `download_url` callers are unchanged (defer defaults off).

## Test plan
- [x] Suite green + stable: 181 tests / 257 assertions (+4 batch tests)
- [x] New tests: sorted output, last-write-wins on duplicate name, existing entry preserved, no-op when all skipped
- [x] Existing install/dev-separation/failure-count tests unchanged and green
- [x] `make sa` + `make lint` clean

Unblocks #24 (parallel installs), which needs the serialized single-write flush.