### PR TITLE
feat(cli): --version flag and install summary line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
   time by default). Set `BASHDEP_JOBS` to change the concurrency;
   `BASHDEP_JOBS=1` restores sequential downloads. Dry-run stays
   sequential for stable preview output.
+- `install` prints a final `installed X, skipped Y, failed Z` summary
+  (suppressed by `silent`).
+- CLI `--version` flag prints the version (alongside the existing
+  `version` command).
 
 ### Changed
 

--- a/bashdep
+++ b/bashdep
@@ -283,8 +283,17 @@ function bashdep::install() {
   fi
 
   BASHDEP_LOCK_DEFER=false
+  # Each newly downloaded dependency contributed exactly one pending entry;
+  # skips and failures contribute none. Capture before flushing/clearing.
+  local installed=${#BASHDEP_LOCK_PENDING[@]}
   bashdep::_lock_flush || failures=$((failures + 1))
   BASHDEP_LOCK_PENDING=()
+
+  if ! bashdep::is_dry_run; then
+    local skipped=$(( ${#dependencies[@]} - installed - failures ))
+    [[ $skipped -lt 0 ]] && skipped=0
+    bashdep::_log "> installed $installed, skipped $skipped, failed $failures"
+  fi
 
   return $(( failures > 255 ? 255 : failures ))
 }
@@ -640,6 +649,7 @@ Options:
   --dry-run             Preview actions without touching disk
   --silent              Suppress informational output
   --verbose             Print extra context
+  --version             Print the bashdep version
   -h, --help            Show this help
 EOF
 }
@@ -657,6 +667,7 @@ function bashdep::main() {
   for arg in "$@"; do
     case $arg in
       -h|--help)   bashdep::usage; return 0 ;;
+      --version)   bashdep::version; return 0 ;;
       --force)     BASHDEP_FORCE=true ;;
       --dry-run)   BASHDEP_DRY_RUN=true ;;
       --silent)    BASHDEP_SILENT=true ;;

--- a/docs/api.md
+++ b/docs/api.md
@@ -35,9 +35,10 @@ Options map 1:1 to [`bashdep::setup`](#bashdepsetup) parameters:
 `--verbose`. `install` also accepts `--file=FILE` to point at a
 dependency file other than `.bashdep`.
 
-Exit codes match the underlying function's return value (e.g. `doctor`
-exits with the issue count), so the CLI drops into CI pipelines as-is.
-Sourcing the script never triggers the CLI.
+`--version` prints the version and `-h`/`--help` prints usage. Exit codes
+match the underlying function's return value (e.g. `doctor` exits with
+the issue count), so the CLI drops into CI pipelines as-is. Sourcing the
+script never triggers the CLI.
 
 ## `bashdep::install`
 

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -456,6 +456,7 @@ function test_bashdep_setup_directory_creates_missing_dir() {
 function test_bashdep_install_custom_setup() {
   mock bashdep::setup_directory "return 0"
   mock bashdep::download_url "echo mocked download_url"
+  BASHDEP_JOBS=1  # deterministic output for the snapshot
   bashdep::setup dir="vendor" dev-dir="src/dev" silent=true
 
   local DEPENDENCIES=(
@@ -470,6 +471,7 @@ function test_bashdep_install_custom_setup() {
 function test_bashdep_install_default_setup() {
   mock bashdep::setup_directory "return 0"
   mock bashdep::download_url "echo mocked download_url"
+  BASHDEP_JOBS=1  # deterministic output for the snapshot
 
   local DEPENDENCIES=(
     "https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit"
@@ -846,6 +848,34 @@ function test_bashdep_install_jobs_one_is_sequential() {
   local lock; lock=$(cat "$TEST_DIR/.bashdep.lock")
   assert_contains "aaa" "$lock"
   assert_contains "bbb" "$lock"
+}
+
+function test_bashdep_install_prints_summary() {
+  # shellcheck disable=SC2016
+  mock curl 'touch "$4"'
+  BASHDEP_DIR="$TEST_DIR"
+  local out; out=$(bashdep::install \
+    "https://example.com/aaa" "https://example.com/bbb")
+  assert_contains "installed 2" "$out"
+}
+
+function test_bashdep_install_summary_counts_skipped() {
+  BASHDEP_DIR="$TEST_DIR"
+  _seed_installed "$TEST_DIR" existing https://example.com/existing
+  # shellcheck disable=SC2016
+  mock curl 'touch "$4"'
+  local out; out=$(bashdep::install \
+    "https://example.com/existing" "https://example.com/new")
+  assert_contains "installed 1, skipped 1, failed 0" "$out"
+}
+
+function test_bashdep_install_summary_suppressed_when_silent() {
+  # shellcheck disable=SC2016
+  mock curl 'touch "$4"'
+  BASHDEP_DIR="$TEST_DIR"
+  BASHDEP_SILENT=true
+  local out; out=$(bashdep::install "https://example.com/aaa")
+  assert_not_contains "installed" "$out"
 }
 
 function test_bashdep_install_from_defaults_to_bashdep_file() {
@@ -1475,6 +1505,10 @@ function test_bashdep_sourcing_does_not_invoke_cli() {
 
 function test_bashdep_cli_short_help_flag_prints_usage() {
   assert_contains "Usage:" "$(bashdep::main -h)"
+}
+
+function test_bashdep_cli_version_flag_prints_version() {
+  assert_equals "$BASHDEP_VERSION" "$(bashdep::main --version)"
 }
 
 function test_bashdep_cli_force_flag_bypasses_skip() {

--- a/tests/unit/snapshots/bashdep_test_sh.test_bashdep_install_default_setup.snapshot
+++ b/tests/unit/snapshots/bashdep_test_sh.test_bashdep_install_default_setup.snapshot
@@ -1,3 +1,4 @@
 mocked download_url
 mocked download_url
 mocked download_url
+> installed 0, skipped 3, failed 0


### PR DESCRIPTION
Closes #35.

- **`--version`** CLI flag prints the version (the `version` command stays too).
- **Install summary**: after `install`/`install_from`, print `installed X, skipped Y, failed Z`. Computed from the aggregated pending-entry count (each newly downloaded dep contributes exactly one pending entry; skips/failures contribute none) — works for both sequential and parallel paths. Suppressed by `--silent`; skipped in dry-run.

## Test plan
- [x] Suite green + stable: 188 tests / 271 assertions (+4)
- [x] New tests: `--version`, summary counts, skipped counting, silent suppression
- [x] Pinned `BASHDEP_JOBS=1` in the two snapshot install tests for deterministic output; updated the `install_default_setup` snapshot with the summary line
- [x] `make sa` + `make lint` clean