### PR TITLE
feat(cli): shell completion (bash + zsh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
   (suppressed by `silent`).
 - CLI `--version` flag prints the version (alongside the existing
   `version` command).
+- CLI `completion [bash|zsh]` prints a shell completion script for the
+  commands and flags. Install with `source <(bashdep completion bash)`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Everyday commands:
 ./lib/bashdep --help           # all commands and flags
 ```
 
+Enable tab completion: `source <(./lib/bashdep completion bash)` (or `zsh`).
+
 ### Or source it from a script
 
 Prefer a programmatic setup (custom dirs, inline arrays)? Source

--- a/bashdep
+++ b/bashdep
@@ -638,6 +638,7 @@ Commands:
   clean                 Remove files not recorded in the lockfile
   doctor                Report lockfile/filesystem inconsistencies
   self-update [ref]     Update bashdep itself (default ref: main)
+  completion [shell]    Print a shell completion script (bash or zsh)
   version               Print the bashdep version
   help                  Show this help
 
@@ -652,6 +653,48 @@ Options:
   --version             Print the bashdep version
   -h, --help            Show this help
 EOF
+}
+
+# Print a shell completion script for the CLI. Usage: completion [bash|zsh]
+# (default bash). Install with: source <(bashdep completion bash)
+# Returns 1 for an unsupported shell.
+function bashdep::completion() {
+  local shell=${1:-bash}
+  local commands="install list uninstall clean doctor self-update completion version help"
+  local flags="--dir --dev-dir --file --force --dry-run --silent --verbose --version --help"
+  case $shell in
+    bash)
+      cat <<EOF
+_bashdep() {
+  local cur="\${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=()
+  if [[ \$COMP_CWORD -eq 1 ]]; then
+    COMPREPLY=( \$(compgen -W "$commands" -- "\$cur") )
+  else
+    COMPREPLY=( \$(compgen -W "$flags" -- "\$cur") )
+  fi
+}
+complete -F _bashdep bashdep
+EOF
+      ;;
+    zsh)
+      cat <<EOF
+#compdef bashdep
+_bashdep() {
+  if (( CURRENT == 2 )); then
+    compadd -- $commands
+  else
+    compadd -- $flags
+  fi
+}
+_bashdep "\$@"
+EOF
+      ;;
+    *)
+      echo "Error: unsupported shell '$shell' (use bash or zsh)." >&2
+      return 1
+      ;;
+  esac
 }
 
 # CLI entry point, invoked when the script is executed rather than sourced.
@@ -719,6 +762,9 @@ function bashdep::main() {
       ;;
     self-update)
       bashdep::self_update ${args[@]+"${args[@]}"}
+      ;;
+    completion)
+      bashdep::completion ${args[@]+"${args[@]}"}
       ;;
     version)
       bashdep::version

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,7 +27,15 @@ no `source` needed:
 ./lib/bashdep clean --dry-run
 ./lib/bashdep doctor
 ./lib/bashdep self-update
+./lib/bashdep completion bash             # or zsh
 ./lib/bashdep --help
+```
+
+Enable shell completion by sourcing the generated script, e.g. in
+`~/.bashrc`:
+
+```bash
+source <(bashdep completion bash)
 ```
 
 Options map 1:1 to [`bashdep::setup`](#bashdepsetup) parameters:

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -1511,6 +1511,37 @@ function test_bashdep_cli_version_flag_prints_version() {
   assert_equals "$BASHDEP_VERSION" "$(bashdep::main --version)"
 }
 
+function test_bashdep_completion_bash_emits_script() {
+  local out; out=$(bashdep::completion bash)
+  assert_contains "complete -F _bashdep bashdep" "$out"
+  assert_contains "install" "$out"
+}
+
+function test_bashdep_completion_defaults_to_bash() {
+  assert_contains "complete -F _bashdep bashdep" "$(bashdep::completion)"
+}
+
+function test_bashdep_completion_zsh_emits_script() {
+  local out; out=$(bashdep::completion zsh)
+  assert_contains "#compdef bashdep" "$out"
+  assert_contains "compadd" "$out"
+}
+
+function test_bashdep_completion_bash_is_valid_syntax() {
+  bashdep::completion bash | bash -n
+  assert_successful_code "$?"
+}
+
+function test_bashdep_completion_unsupported_shell_fails() {
+  local err; err=$(bashdep::completion fish 2>&1 >/dev/null)
+  assert_general_error
+  assert_contains "unsupported shell" "$err"
+}
+
+function test_bashdep_cli_completion_dispatches() {
+  assert_contains "complete -F _bashdep" "$(bashdep::main completion bash)"
+}
+
 function test_bashdep_cli_force_flag_bypasses_skip() {
   local url="https://example.com/tool"
   _seed_installed "$TEST_DIR" tool "$url"


### PR DESCRIPTION
Closes #36.

- New `bashdep completion [bash|zsh]` (default bash) prints a completion script for the commands (`install`, `list`, `uninstall`, `clean`, `doctor`, `self-update`, `completion`, `version`, `help`) and the flags.
- Dependency-free and Bash 3.2-safe to emit; the generated bash script passes `bash -n`.
- Install: `source <(bashdep completion bash)`.

## Test plan
- [x] Suite green + stable: 194 tests / 277 assertions (+7)
- [x] Tests: bash/zsh/default emit, **emitted bash validated with `bash -n`**, unsupported-shell error, CLI dispatch
- [x] `make sa` + `make lint` clean
- [x] Docs (api.md, README) + CHANGELOG (Added) updated