### PR TITLE
feat(install): opt-in checksum verification for downloaded deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
   commands and flags. Install with `source <(bashdep completion bash)`.
 - `bashdep::doctor` now reports malformed lockfile lines (not exactly two
   tab-separated fields), catching merge-conflict or hand-edit damage.
+- Opt-in checksum verification: append `#sha256=<hex>` to a dependency
+  URL and bashdep verifies the download's SHA-256 before recording it.
+  On mismatch the install fails and leaves no file or lockfile entry.
 
 ### Changed
 

--- a/bashdep
+++ b/bashdep
@@ -361,6 +361,14 @@ function bashdep::_install_one_async() {
 # Sets BASHDEP_DEP_URL and BASHDEP_DEP_DIR. Pure (no I/O).
 function bashdep::_classify_dep() {
   local dep=$1
+  # Optional integrity annotation: a trailing '#sha256=<hex>' is stripped
+  # off and recorded in BASHDEP_DEP_SHA for download_url to verify.
+  if [[ "$dep" == *"#sha256="* ]]; then
+    BASHDEP_DEP_SHA="${dep#*#sha256=}"
+    dep="${dep%#sha256=*}"
+  else
+    BASHDEP_DEP_SHA=""
+  fi
   if [[ "$dep" == *"$BASHDEP_DEV_SUFFIX" ]]; then
     BASHDEP_DEP_URL="${dep%"$BASHDEP_DEV_SUFFIX"}"
     BASHDEP_DEP_DIR="$BASHDEP_DEV_DIR"
@@ -428,6 +436,18 @@ function bashdep::download_url() {
     return 1
   fi
 
+  local expected_sha="${BASHDEP_DEP_SHA:-}"
+  if [[ -n "$expected_sha" ]]; then
+    local actual_sha
+    actual_sha=$(bashdep::_sha256 "$destination_file") || { rm -f "$destination_file"; return 1; }
+    if [[ "$actual_sha" != "$expected_sha" ]]; then
+      rm -f "$destination_file"
+      echo "Error: checksum mismatch for $file_name (expected $expected_sha, got $actual_sha)" >&2
+      return 1
+    fi
+    bashdep::_vlog "  sha256 verified: $file_name"
+  fi
+
   bashdep::_log "> $file_name installed successfully in '$destination_dir'"
   chmod +x "$destination_file"
   if [[ "$BASHDEP_LOCK_DEFER" == true ]]; then
@@ -441,6 +461,20 @@ function bashdep::download_url() {
 # Internal: capability checks for the supported downloaders.
 function bashdep::_has_curl() { command -v curl >/dev/null 2>&1; }
 function bashdep::_has_wget() { command -v wget >/dev/null 2>&1; }
+
+# Internal: print the SHA-256 hex of a file, portable across macOS
+# (shasum) and Linux (sha256sum). Returns 1 if neither tool is available.
+function bashdep::_sha256() {
+  local file=$1
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$file" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$file" | awk '{print $1}'
+  else
+    echo "Error: need 'shasum' or 'sha256sum' to verify checksums." >&2
+    return 1
+  fi
+}
 
 # Internal: download $1 (url) into $2 (output path). Prefers curl and falls
 # back to wget when curl is not installed. Returns the downloader's own exit

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -53,6 +53,22 @@ DEPENDENCIES=(
 Each directory keeps its own `.bashdep.lock`. `bashdep::list` reads
 both by default.
 
+## Checksum verification (opt-in)
+
+Append `#sha256=<hex>` to a dependency URL to have bashdep verify the
+download's SHA-256 before recording it:
+
+```
+https://example.com/tool.sh#sha256=e3b0c44298fc1c149afbf4c8996fb924...
+https://example.com/dev-tool.sh@dev#sha256=2c26b46b68ffc68ff99b453c...
+```
+
+The annotation is stripped before download (`curl`/`wget` never see it)
+and can combine with the `@dev` suffix. On a mismatch — or when neither
+`shasum` nor `sha256sum` is available — the download fails, the file is
+removed, and no lockfile entry is written. Without the annotation,
+nothing is verified (the default).
+
 ## Error handling
 
 - `bashdep::install` downloads in parallel (up to `BASHDEP_JOBS`, default

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -13,6 +13,7 @@ function set_up() {
   BASHDEP_DOWNLOADER=""
   BASHDEP_LOCK_DEFER=false
   BASHDEP_LOCK_PENDING=()
+  BASHDEP_DEP_SHA=""
   TEST_DIR=$(mktemp -d)
   BASHDEP_BIN="$(cd "$(current_dir)/../.." && pwd)/bashdep"
 }
@@ -65,6 +66,27 @@ function test_bashdep_classify_dep_honors_overridden_dirs() {
   bashdep::_classify_dep "https://example.com/foo@dev"
   assert_equals "https://example.com/foo" "$BASHDEP_DEP_URL"
   assert_equals "src/dev"                 "$BASHDEP_DEP_DIR"
+}
+
+function test_bashdep_classify_dep_parses_sha256_annotation() {
+  BASHDEP_DIR=lib BASHDEP_DEV_DIR=lib/dev BASHDEP_DEV_SUFFIX=@dev
+  bashdep::_classify_dep "https://example.com/foo#sha256=abc123"
+  assert_equals "https://example.com/foo" "$BASHDEP_DEP_URL"
+  assert_equals "abc123"                  "$BASHDEP_DEP_SHA"
+}
+
+function test_bashdep_classify_dep_sha256_combined_with_dev() {
+  BASHDEP_DIR=lib BASHDEP_DEV_DIR=lib/dev BASHDEP_DEV_SUFFIX=@dev
+  bashdep::_classify_dep "https://example.com/foo@dev#sha256=deadbeef"
+  assert_equals "https://example.com/foo" "$BASHDEP_DEP_URL"
+  assert_equals "lib/dev"                 "$BASHDEP_DEP_DIR"
+  assert_equals "deadbeef"                "$BASHDEP_DEP_SHA"
+}
+
+function test_bashdep_classify_dep_no_annotation_leaves_sha_empty() {
+  BASHDEP_DIR=lib BASHDEP_DEV_DIR=lib/dev BASHDEP_DEV_SUFFIX=@dev
+  bashdep::_classify_dep "https://example.com/foo"
+  assert_empty "$BASHDEP_DEP_SHA"
 }
 
 function test_bashdep_is_silent_true_when_var_true() {
@@ -678,6 +700,57 @@ function test_bashdep_download_url_works_with_wget_fallback() {
   bashdep::download_url "https://example.com/tool" "$TEST_DIR" >/dev/null
   assert_file_exists "$TEST_DIR/tool"
   assert_file_exists "$TEST_DIR/.bashdep.lock"
+}
+
+function test_bashdep_download_url_accepts_matching_checksum() {
+  # shellcheck disable=SC2016
+  mock curl 'printf "hello\n" > "$3"'
+  printf 'hello\n' > "$TEST_DIR/ref"
+  BASHDEP_DEP_SHA=$(bashdep::_sha256 "$TEST_DIR/ref")
+  bashdep::download_url "https://example.com/tool" "$TEST_DIR" >/dev/null
+  assert_file_exists "$TEST_DIR/tool"
+  assert_file_exists "$TEST_DIR/.bashdep.lock"
+}
+
+function test_bashdep_download_url_rejects_mismatching_checksum() {
+  # shellcheck disable=SC2016
+  mock curl 'printf "hello\n" > "$3"'
+  BASHDEP_DEP_SHA="0000000000000000000000000000000000000000000000000000000000000000"
+  bashdep::download_url "https://example.com/tool" "$TEST_DIR" 2>/dev/null
+  assert_general_error
+  assert_file_not_exists "$TEST_DIR/tool"
+  assert_file_not_exists "$TEST_DIR/.bashdep.lock"
+}
+
+function test_bashdep_download_url_fails_when_checksum_tool_missing() {
+  # shellcheck disable=SC2016
+  mock curl 'printf "x" > "$3"'
+  mock bashdep::_sha256 "return 1"
+  BASHDEP_DEP_SHA="anything"
+  bashdep::download_url "https://example.com/tool" "$TEST_DIR" 2>/dev/null
+  assert_general_error
+  assert_file_not_exists "$TEST_DIR/tool"
+}
+
+function test_bashdep_install_verifies_checksum_annotation() {
+  BASHDEP_DIR="$TEST_DIR"
+  BASHDEP_JOBS=1
+  printf 'hello\n' > "$TEST_DIR/ref"
+  local sha; sha=$(bashdep::_sha256 "$TEST_DIR/ref")
+  # shellcheck disable=SC2016
+  mock curl 'printf "hello\n" > "$3"'
+  bashdep::install "https://example.com/tool#sha256=$sha" >/dev/null
+  assert_file_exists "$TEST_DIR/tool"
+}
+
+function test_bashdep_install_rejects_bad_checksum_annotation() {
+  BASHDEP_DIR="$TEST_DIR"
+  BASHDEP_JOBS=1
+  # shellcheck disable=SC2016
+  mock curl 'printf "hello\n" > "$3"'
+  bashdep::install "https://example.com/tool#sha256=wrong" >/dev/null 2>&1
+  assert_equals 1 "$?"
+  assert_file_not_exists "$TEST_DIR/tool"
 }
 
 function test_bashdep_download_url_returns_zero_when_verbose_off() {


### PR DESCRIPTION
Closes #38.

Append `#sha256=<hex>` to a dependency URL to verify its SHA-256:

```
https://example.com/tool.sh#sha256=e3b0c44298fc1c149afbf4c8996fb924...
https://example.com/dev-tool.sh@dev#sha256=2c26b46b...
```

- `_classify_dep` strips the annotation into `BASHDEP_DEP_SHA` **before** download (curl/wget never see it) and it composes with `@dev`. Flows through the parallel path via the existing `BASHDEP_DEP_*` global pattern.
- `download_url` computes the hash with a portable `_sha256` (shasum/sha256sum). On mismatch **or** a missing checksum tool, it removes the file and does not write a lockfile entry, returning non-zero.
- **Off by default** — no annotation, no verification. No `.bashdep` format change (the annotation rides on the URL token, so `install_from` is untouched).

## Test plan
- [x] Suite green + stable: 204 tests / 297 assertions (+11)
- [x] Tests: classify parses annotation (alone + with @dev + none), download match/mismatch/missing-tool, install-level match + reject
- [x] `make sa` + `make lint` clean; behavior.md + CHANGELOG updated