### PR TITLE
dx: toolchain docs + pre-commit config

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,16 +25,34 @@ docs/                       # API + behavior + releasing reference
 Makefile                    # test / sa / lint / deps / release / pre_commit/install
 ```
 
-The codebase is intentionally small and zero-runtime: only `curl`,
-`awk`, `mktemp`, and POSIX-ish utilities at runtime. Tests run on
-bash 3.2+ (default macOS) and bash 4+ (Linux CI).
+The codebase is intentionally small and zero-runtime: only `curl` (or
+`wget`), `awk`, `mktemp`, and POSIX-ish utilities at runtime. Tests run
+on bash 3.2+ (default macOS) and bash 4+ (Linux CI).
+
+## Toolchain
+
+Install these to run the full gate locally:
+
+| Tool | Purpose | Install |
+| --- | --- | --- |
+| [bashunit](https://bashunit.typeddevs.com/) `0.17.0` | Test runner | `make deps` |
+| [ShellCheck](https://www.shellcheck.net/) | Static analysis (`make sa`) | `brew install shellcheck` / `apt install shellcheck` |
+| [editorconfig-checker](https://editorconfig-checker.github.io/) | Whitespace/indent lint (`make lint`) | `brew install editorconfig-checker` |
+
+`make lint` finds the linter under either the `ec` or
+`editorconfig-checker` binary name.
 
 ## Workflow for pull requests
 
 1. Fork/clone, branch from `main`.
 2. Implement the change and add tests for it.
-3. Run `make pre_commit/run` (test + ShellCheck + editorconfig).
+3. Run `make check` (test + ShellCheck + editorconfig).
 4. Open the PR with a short summary and a test plan.
+
+Prefer commit-time enforcement? Either `make pre_commit/install` (a
+plain git hook) or, with the [pre-commit](https://pre-commit.com)
+framework, `pip install pre-commit && pre-commit install` — the
+committed `.pre-commit-config.yaml` runs the same Makefile gates.
 
 Set your git `user.name` / `user.email` so commit history stays clean:
 see [first-time setup](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+# Optional: run the same gates as CI on every commit via the pre-commit
+# framework (https://pre-commit.com). Install with:
+#   pip install pre-commit && pre-commit install
+# These local hooks reuse the Makefile targets, so there are no external
+# hook repositories to fetch.
+repos:
+  - repo: local
+    hooks:
+      - id: shellcheck
+        name: ShellCheck
+        entry: make sa
+        language: system
+        pass_filenames: false
+        files: '(\.sh$|^bashdep$|^release\.sh$|^bin/pre-commit$)'
+      - id: editorconfig
+        name: editorconfig-checker
+        entry: make lint
+        language: system
+        pass_filenames: false
+      - id: tests
+        name: bashunit tests
+        entry: make test
+        language: system
+        pass_filenames: false
+        files: '(\.sh$|^bashdep$|^release\.sh$|^tests/)'


### PR DESCRIPTION
Closes #34.

- **CONTRIBUTING**: a Toolchain table (bashunit `0.17.0`, ShellCheck, editorconfig-checker — purpose, version, install command); notes that `make lint` accepts either `ec` or `editorconfig-checker`; PR workflow now points at `make check`.
- **`.pre-commit-config.yaml`**: local hooks that reuse the Makefile gates (`make sa`/`make lint`/`make test`) — no external hook repos to fetch, consistent with the zero-dep ethos. `pip install pre-commit && pre-commit install` runs the same gate on commit.

## Test plan
- [x] `ec` clean on the new YAML; `make check` green
- [x] Local hooks mirror the existing `bin/pre-commit` skip logic (`files:` patterns)
- [x] Docs/config only — no library or public-API change