### PR TITLE
feat(release): --trust-ci to skip local gates on a green HEAD

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -73,6 +73,7 @@ not source.
 | `--dry-run`      | Preview every step. No file/git/network changes.            |
 | `--force`        | Skip the interactive `Release X.Y.Z?` confirmation.         |
 | `--no-gh`        | Skip the GitHub release step (still pushes commit + tag).   |
+| `--trust-ci`     | Skip the local `test/sa/lint` gate when HEAD already has a green CI run (needs `gh`); otherwise runs the gate. |
 | `--remote=NAME`  | Push to a remote other than `origin`.                       |
 
 CI mode (no prompts, no `gh` step):

--- a/release.sh
+++ b/release.sh
@@ -49,6 +49,7 @@ BUMP_LEVEL="minor"
 DRY_RUN=false
 FORCE=false
 WITH_GH_RELEASE=true
+TRUST_CI=false
 REMOTE="origin"
 
 # --- Output helpers ----------------------------------------------------------
@@ -121,6 +122,8 @@ Options:
   --dry-run     Preview every step without mutating files, git, or network.
   --force       Skip interactive confirmation.
   --no-gh       Skip the GitHub release step.
+  --trust-ci    Skip the local test/sa/lint gate when HEAD already has a
+                green CI run (requires gh). Falls back to running it.
   --remote=NAME Push to a remote other than origin.
   -h, --help    Show this help.
 
@@ -143,6 +146,7 @@ parse_args() {
       --dry-run) DRY_RUN=true ;;
       --force)   FORCE=true ;;
       --no-gh)   WITH_GH_RELEASE=false ;;
+      --trust-ci) TRUST_CI=true ;;
       --remote=*) REMOTE="${1#*=}" ;;
       -*)        err "Unknown flag: $1"; usage >&2; exit 1 ;;
       *)
@@ -215,7 +219,7 @@ preflight() {
       exit 1
     fi
   fi
-  if $WITH_GH_RELEASE; then require_cmd gh; fi
+  if $WITH_GH_RELEASE || $TRUST_CI; then require_cmd gh; fi
   ok "required commands present"
 
   local branch
@@ -354,10 +358,34 @@ roll_changelog() {
   done_ok "CHANGELOG rolled (Unreleased → $VERSION on $today)"
 }
 
+# Print the combined check-runs conclusion for the current HEAD commit:
+# "success", "failure", "pending", or "none" (no checks / lookup failed).
+ci_head_conclusion() {
+  local sha
+  sha=$(git rev-parse HEAD)
+  gh api "repos/$REPO_PATH/commits/$sha/check-runs" --jq '
+    def ok: .conclusion == "success" or .conclusion == "skipped" or .conclusion == "neutral";
+    if (.check_runs | length) == 0 then "none"
+    elif any(.check_runs[]; .status != "completed") then "pending"
+    elif all(.check_runs[]; ok) then "success"
+    else "failure" end' 2>/dev/null || echo "none"
+}
+
+# Return 0 when --trust-ci was passed and HEAD already has a green CI run,
+# so the local gates can be safely skipped.
+should_skip_gates() {
+  $TRUST_CI || return 1
+  [[ "$(ci_head_conclusion)" == "success" ]]
+}
+
 run_gates() {
   log "Run release gates (test + sa + lint)"
   if $DRY_RUN; then
-    plan "make test sa lint"
+    plan "make test sa lint (unless --trust-ci and HEAD is green)"
+    return
+  fi
+  if should_skip_gates; then
+    ok "trusting green CI on HEAD — skipping local gates"
     return
   fi
   make test >/dev/null

--- a/tests/unit/release_test.sh
+++ b/tests/unit/release_test.sh
@@ -47,6 +47,41 @@ function test_release_bump_version_minor_resets_patch() {
   assert_equals "1.3.0" "$(bump_version_string 1.2.9 minor)"
 }
 
+# --- --trust-ci gate-skip decision -------------------------------------------
+
+function test_release_should_skip_gates_false_without_trust_ci() {
+  TRUST_CI=false
+  should_skip_gates
+  assert_general_error
+}
+
+function test_release_should_skip_gates_true_when_ci_green() {
+  TRUST_CI=true
+  mock ci_head_conclusion "echo success"
+  should_skip_gates
+  assert_successful_code "$?"
+}
+
+function test_release_should_skip_gates_false_when_ci_failed() {
+  TRUST_CI=true
+  mock ci_head_conclusion "echo failure"
+  should_skip_gates
+  assert_general_error
+}
+
+function test_release_should_skip_gates_false_when_ci_pending() {
+  TRUST_CI=true
+  mock ci_head_conclusion "echo pending"
+  should_skip_gates
+  assert_general_error
+}
+
+function test_release_ci_head_conclusion_returns_gh_output() {
+  mock git "echo deadsha"
+  mock gh "echo success"
+  assert_equals "success" "$(ci_head_conclusion)"
+}
+
 # --- sha256_of ---------------------------------------------------------------
 
 function test_release_sha256_of_records_basename_not_path() {


### PR DESCRIPTION
Closes #40.

- `release.sh --trust-ci` consults HEAD's GitHub **check-runs** (`gh api repos/.../commits/<sha>/check-runs --jq`) and skips the local `make test/sa/lint` gate when every run concluded success/skipped/neutral. Otherwise (failure, pending, none, or no `--trust-ci`) it runs the gate as before — never skips unsafely.
- Split into `ci_head_conclusion` (returns success/failure/pending/none) and `should_skip_gates` (TRUST_CI + green) so the decision is unit-testable with a stubbed `gh`.
- Preflight requires `gh` when `--trust-ci`. Dry-run notes the conditional.

## Test plan
- [x] release_test 17/17 (+5): skip-false without flag, skip-true on green, skip-false on failure/pending, `ci_head_conclusion` returns gh output (stubbed git+gh)
- [x] Full suite 209 green; `make sa` + `make lint` clean
- [x] `./release.sh --dry-run --trust-ci` previews correctly; docs/releasing.md updated