### PR TITLE
chore: second quality sweep (8-agent audit) — incl. BASHDEP_JOBS injection fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 - `bashdep::install` downloads dependencies in parallel (up to 4 at a
   time by default). Set `BASHDEP_JOBS` to change the concurrency;
   `BASHDEP_JOBS=1` restores sequential downloads. Dry-run stays
-  sequential for stable preview output.
+  sequential for stable preview output. `BASHDEP_JOBS` must be a
+  non-negative integer; any other value is rejected with a warning and
+  the default of `4` is used (the count feeds an arithmetic test, so a
+  crafted value is never evaluated as an expression).
 - `install` prints a final `installed X, skipped Y, failed Z` summary
   (suppressed by `silent`).
 - CLI `--version` flag prints the version (alongside the existing

--- a/bashdep
+++ b/bashdep
@@ -263,6 +263,22 @@ function bashdep::list() {
   done
 }
 
+# Internal: resolve the parallel job count from BASHDEP_JOBS. The value
+# feeds an arithmetic `[[ -gt ]]` test, so only a plain non-negative integer
+# is honored; any other value — a non-numeric string, or an
+# arithmetic-injection payload such as 'a[$(cmd)]' — is rejected with a
+# warning and the default of 4 is used. Prints the resolved integer.
+function bashdep::_resolve_jobs() {
+  local raw="${BASHDEP_JOBS:-4}"
+  case "$raw" in
+    ''|*[!0-9]*)
+      echo "Error: BASHDEP_JOBS must be a non-negative integer, got '$raw'; using 4." >&2
+      raw=4
+      ;;
+  esac
+  printf '%s' "$raw"
+}
+
 # Download and install all dependencies.
 # Returns 0 if all succeed, otherwise the number of failures (capped at 255
 # since bash return codes are 8-bit).
@@ -270,7 +286,8 @@ function bashdep::install() {
   local dependencies=("$@")
   local failures=0
   local dep
-  local jobs="${BASHDEP_JOBS:-4}"
+  local jobs
+  jobs=$(bashdep::_resolve_jobs)
 
   # Defer lockfile writes: each download records its entry in
   # BASHDEP_LOCK_PENDING and we rewrite each destination lockfile once at

--- a/bashdep
+++ b/bashdep
@@ -286,9 +286,7 @@ function bashdep::install() {
     failures=$?
   else
     for dep in "${dependencies[@]}"; do
-      bashdep::_classify_dep "$dep"
-      bashdep::setup_directory "$BASHDEP_DEP_DIR" || { failures=$((failures + 1)); continue; }
-      bashdep::download_url "$BASHDEP_DEP_URL" "$BASHDEP_DEP_DIR" || failures=$((failures + 1))
+      bashdep::_install_one "$dep" || failures=$((failures + 1))
     done
   fi
 
@@ -348,13 +346,24 @@ function bashdep::_install_parallel() {
 # its deferred lockfile entry to $2. Returns non-zero on failure.
 function bashdep::_install_one_async() {
   local dep=$1 result_file=$2 entry
-  bashdep::_classify_dep "$dep"
-  bashdep::setup_directory "$BASHDEP_DEP_DIR" || return 1
   BASHDEP_LOCK_PENDING=()
-  bashdep::download_url "$BASHDEP_DEP_URL" "$BASHDEP_DEP_DIR" || return 1
+  bashdep::_install_one "$dep" || return 1
   for entry in ${BASHDEP_LOCK_PENDING[@]+"${BASHDEP_LOCK_PENDING[@]}"}; do
     printf '%s\n' "$entry" >> "$result_file"
   done
+}
+
+# Internal: install one dependency — classify it, ensure its destination
+# directory exists, then download it. _classify_dep sets BASHDEP_DEP_URL and
+# BASHDEP_DEP_DIR, which the two later steps consume. Returns non-zero when
+# the directory cannot be created or the download fails. Shared by the
+# sequential and parallel (async) install paths so the ordering and error
+# semantics live in one place.
+function bashdep::_install_one() {
+  local dep=$1
+  bashdep::_classify_dep "$dep"
+  bashdep::setup_directory "$BASHDEP_DEP_DIR" || return 1
+  bashdep::download_url "$BASHDEP_DEP_URL" "$BASHDEP_DEP_DIR" || return 1
 }
 
 # Internal: classify a dependency string into URL and target directory.

--- a/bashdep
+++ b/bashdep
@@ -4,6 +4,7 @@ BASHDEP_VERSION="0.6.0"
 BASHDEP_DIR="lib"
 BASHDEP_DEV_DIR="lib/dev"
 BASHDEP_DEV_SUFFIX="@dev"
+BASHDEP_SHA_ANNOTATION="#sha256="
 BASHDEP_LOCK_FILE=".bashdep.lock"
 BASHDEP_DEP_FILE=".bashdep"
 BASHDEP_SILENT=false
@@ -361,11 +362,12 @@ function bashdep::_install_one_async() {
 # Sets BASHDEP_DEP_URL and BASHDEP_DEP_DIR. Pure (no I/O).
 function bashdep::_classify_dep() {
   local dep=$1
-  # Optional integrity annotation: a trailing '#sha256=<hex>' is stripped
-  # off and recorded in BASHDEP_DEP_SHA for download_url to verify.
-  if [[ "$dep" == *"#sha256="* ]]; then
-    BASHDEP_DEP_SHA="${dep#*#sha256=}"
-    dep="${dep%#sha256=*}"
+  # Optional integrity annotation: a trailing BASHDEP_SHA_ANNOTATION marker
+  # ('#sha256=<hex>') is stripped off and recorded in BASHDEP_DEP_SHA for
+  # download_url to verify.
+  if [[ "$dep" == *"$BASHDEP_SHA_ANNOTATION"* ]]; then
+    BASHDEP_DEP_SHA="${dep#*"$BASHDEP_SHA_ANNOTATION"}"
+    dep="${dep%"$BASHDEP_SHA_ANNOTATION"*}"
   else
     BASHDEP_DEP_SHA=""
   fi

--- a/docs/api.md
+++ b/docs/api.md
@@ -61,8 +61,10 @@ bashdep::install "${DEPENDENCIES[@]}"
 ```
 
 Downloads run in parallel, up to `BASHDEP_JOBS` at a time (default `4`).
-Set `BASHDEP_JOBS=1` for sequential downloads. Returns the number of
-failed downloads (0 on success, capped at 255).
+Set `BASHDEP_JOBS=1` for sequential downloads. `BASHDEP_JOBS` must be a
+non-negative integer; any other value is rejected with a warning and the
+default of `4` is used. Returns the number of failed downloads (0 on
+success, capped at 255).
 
 ## `bashdep::install_from`
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -72,8 +72,11 @@ nothing is verified (the default).
 ## Error handling
 
 - `bashdep::install` downloads in parallel (up to `BASHDEP_JOBS`, default
-  `4`; set `BASHDEP_JOBS=1` for sequential). It continues past failed
-  downloads and returns the failure count (capped at 255). Lockfile
+  `4`; set `BASHDEP_JOBS=1` for sequential). `BASHDEP_JOBS` must be a
+  non-negative integer; a non-numeric or otherwise invalid value is
+  rejected with a warning and the default of `4` is used. It continues
+  past failed downloads and returns the failure count (capped at 255).
+  Lockfile
   writes are batched into a single rewrite per directory after all
   downloads finish, so concurrency never corrupts the lockfile.
 - `bashdep::install_from` returns `1` if the file (default: `.bashdep`)

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# Pin to the same bashunit version used in CI (.github/workflows/tests.yml).
+# Pin to the same bashunit version used in CI (.github/workflows/ci.yml).
 BASHUNIT_VERSION="${BASHUNIT_VERSION:-0.17.0}"
 
 echo "Installing bashunit ${BASHUNIT_VERSION} into lib/..."

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -14,6 +14,7 @@ function set_up() {
   BASHDEP_LOCK_DEFER=false
   BASHDEP_LOCK_PENDING=()
   BASHDEP_DEP_SHA=""
+  BASHDEP_JOBS=4
   TEST_DIR=$(mktemp -d)
   BASHDEP_BIN="$(cd "$(current_dir)/../.." && pwd)/bashdep"
 }
@@ -87,6 +88,27 @@ function test_bashdep_classify_dep_no_annotation_leaves_sha_empty() {
   BASHDEP_DIR=lib BASHDEP_DEV_DIR=lib/dev BASHDEP_DEV_SUFFIX=@dev
   bashdep::_classify_dep "https://example.com/foo"
   assert_empty "$BASHDEP_DEP_SHA"
+}
+
+function test_bashdep_resolve_jobs_accepts_positive_integer() {
+  BASHDEP_JOBS=8
+  assert_equals "8" "$(bashdep::_resolve_jobs)"
+}
+
+function test_bashdep_resolve_jobs_defaults_to_four_when_unset() {
+  unset BASHDEP_JOBS
+  assert_equals "4" "$(bashdep::_resolve_jobs)"
+}
+
+function test_bashdep_resolve_jobs_rejects_non_numeric() {
+  BASHDEP_JOBS="foo"
+  assert_equals "4" "$(bashdep::_resolve_jobs 2>/dev/null)"
+}
+
+function test_bashdep_resolve_jobs_rejects_arithmetic_injection_payload() {
+  # shellcheck disable=SC2016  # the $(...) must stay literal, not expand here
+  BASHDEP_JOBS='x[$(echo hacked)]'
+  assert_equals "4" "$(bashdep::_resolve_jobs 2>/dev/null)"
 }
 
 function test_bashdep_is_silent_true_when_var_true() {
@@ -910,6 +932,19 @@ function test_bashdep_install_parallel_counts_failures() {
   BASHDEP_JOBS=4
   bashdep::install "https://example.com/a" "https://example.com/b" "https://example.com/c"
   assert_equals 3 "$?"
+}
+
+function test_bashdep_install_neutralizes_arithmetic_injection_in_jobs() {
+  BASHDEP_DIR="$TEST_DIR"
+  local marker="$TEST_DIR/pwned"
+  # BASHDEP_JOBS feeds an arithmetic `[[ -gt ]]` test; a crafted value must
+  # never be evaluated as an arithmetic expression (which executes code).
+  # shellcheck disable=SC2016  # the $(...) must stay literal, not expand here
+  BASHDEP_JOBS='x[$(touch '"$marker"')]'
+  # shellcheck disable=SC2016
+  mock curl 'touch "$3"'
+  bashdep::install "https://example.com/aaa" "https://example.com/bbb" >/dev/null 2>&1
+  assert_file_not_exists "$marker"
 }
 
 function test_bashdep_install_jobs_one_is_sequential() {

--- a/tests/unit/release_test.sh
+++ b/tests/unit/release_test.sh
@@ -76,10 +76,29 @@ function test_release_should_skip_gates_false_when_ci_pending() {
   assert_general_error
 }
 
+# Fail-safe: a CI lookup that could not determine a green run (yields "none")
+# must NOT skip the gates, even under --trust-ci. Guards against the gate
+# ever failing open.
+function test_release_should_skip_gates_false_when_ci_lookup_fails() {
+  TRUST_CI=true
+  mock ci_head_conclusion "echo none"
+  should_skip_gates
+  assert_general_error
+}
+
 function test_release_ci_head_conclusion_returns_gh_output() {
   mock git "echo deadsha"
   mock gh "echo success"
   assert_equals "success" "$(ci_head_conclusion)"
+}
+
+# Fail-safe: when the gh lookup itself fails (network/auth/rate-limit), the
+# conclusion must fall back to "none" — the conservative value that makes
+# should_skip_gates run the gates. It must never surface as "success".
+function test_release_ci_head_conclusion_returns_none_when_gh_fails() {
+  mock git "echo deadsha"
+  mock gh "return 1"
+  assert_equals "none" "$(ci_head_conclusion)"
 }
 
 # --- sha256_of ---------------------------------------------------------------


### PR DESCRIPTION
Second 8-way code-quality audit (DRY, shared constants, unused, circular deps, weak/loose handling, defensive programming, legacy, comments) over the code added since the last sweep (parallel install, batch flush, checksum verify, completion, `--trust-ci`). **5 of 8 axes found nothing to change**; the rest produced high-confidence, test-backed changes — including one genuine security fix.

### Changes landed

- **`fix(install): validate BASHDEP_JOBS before arithmetic use`** (weak/loose handling) — **security fix.** `BASHDEP_JOBS` flowed unvalidated into `[[ "$jobs" -gt 1 ]]`, which evaluates operands as *arithmetic*, so `BASHDEP_JOBS='a[$(cmd)]'` executed `cmd`. New `_resolve_jobs` accepts only a non-negative integer via a `case` glob (no eval), else warns and falls back to 4. +5 tests incl. an RED-proven injection regression. Vuln was in **unreleased** code — no shipped regression.
- **`ref(install): extract _install_one`** (DRY) — the classify→setup_directory→download_url sequence was duplicated between `install`'s sequential loop and `_install_one_async`; now shared. Behavior-identical, existing tests cover both paths.
- **`ref(install): promote #sha256= to BASHDEP_SHA_ANNOTATION`** (constants) — the wire-format token was a bare literal repeated 3× in `_classify_dep`; now a named global next to `BASHDEP_DEV_SUFFIX`.
- **`test(release): lock in fail-safe of the --trust-ci gate`** (defensive) — +2 regression tests proving `ci_head_conclusion` returns `none` (not `success`) on gh failure, so a broken lookup never skips the release gate.
- **`docs: fix stale CI workflow reference`** — `install-dependencies.sh` pointed at the old `tests.yml` (renamed to `ci.yml` in #54).

### Axes that found nothing (verified)

- **Unused** — all 38 functions reachable; ShellCheck `--enable=all` 0× SC2317/SC2034.
- **Circular deps** — strict DAG; new parallel background-job functions have no ordering hazard. madge N/A.
- **Legacy** — no shims; the dual paths (curl/wget, sequential/parallel, deferred/inline writes) are all live + tested; Bash 3.2 constructs preserved.
- **Comments** — API contracts, shellcheck reasons, why-notes all legitimate.
- Cross-file `_sha256`/`sha256_of` dedup deliberately **not** done (different contracts; would couple the zero-dep library into release tooling).

## Test plan

- [x] Suite: **216 tests / 309 assertions**, green (was 209/302) — +7 across the fixes
- [x] `make sa` + `make lint` clean
- [x] Integration conflicts: none — the four change-branches auto-merged (Frodo × Legolas both touch `install` on different lines)
- [x] Docs (api.md, behavior.md) + CHANGELOG updated for the JOBS validation