### PR TITLE
fix(install): reject empty or non-hex #sha256= annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
   tab-separated fields), catching merge-conflict or hand-edit damage.
 - Opt-in checksum verification: append `#sha256=<hex>` to a dependency
   URL and bashdep verifies the download's SHA-256 before recording it.
-  On mismatch the install fails and leaves no file or lockfile entry.
+  On mismatch the install fails and leaves no file or lockfile entry. A
+  present-but-empty or non-hex annotation is rejected up front rather
+  than silently skipping verification.
 
 ### Changed
 

--- a/bashdep
+++ b/bashdep
@@ -378,7 +378,7 @@ function bashdep::_install_one_async() {
 # semantics live in one place.
 function bashdep::_install_one() {
   local dep=$1
-  bashdep::_classify_dep "$dep"
+  bashdep::_classify_dep "$dep" || return 1
   bashdep::setup_directory "$BASHDEP_DEP_DIR" || return 1
   bashdep::download_url "$BASHDEP_DEP_URL" "$BASHDEP_DEP_DIR" || return 1
 }
@@ -394,6 +394,12 @@ function bashdep::_classify_dep() {
   if [[ "$dep" == *"$BASHDEP_SHA_ANNOTATION"* ]]; then
     BASHDEP_DEP_SHA="${dep#*"$BASHDEP_SHA_ANNOTATION"}"
     dep="${dep%"$BASHDEP_SHA_ANNOTATION"*}"
+    # Reject a present-but-empty or non-hex pin loudly, rather than
+    # silently skipping verification the caller asked for.
+    if [[ -z "$BASHDEP_DEP_SHA" || "$BASHDEP_DEP_SHA" == *[!0-9a-fA-F]* ]]; then
+      echo "Error: invalid '$BASHDEP_SHA_ANNOTATION' value (expected a hex sha256)." >&2
+      return 1
+    fi
   else
     BASHDEP_DEP_SHA=""
   fi

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -66,8 +66,10 @@ https://example.com/dev-tool.sh@dev#sha256=2c26b46b68ffc68ff99b453c...
 The annotation is stripped before download (`curl`/`wget` never see it)
 and can combine with the `@dev` suffix. On a mismatch — or when neither
 `shasum` nor `sha256sum` is available — the download fails, the file is
-removed, and no lockfile entry is written. Without the annotation,
-nothing is verified (the default).
+removed, and no lockfile entry is written. A present-but-empty or
+non-hex annotation (e.g. `#sha256=`) is rejected before download rather
+than silently skipping the check. Without the annotation, nothing is
+verified (the default).
 
 ## Error handling
 

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -90,6 +90,18 @@ function test_bashdep_classify_dep_no_annotation_leaves_sha_empty() {
   assert_empty "$BASHDEP_DEP_SHA"
 }
 
+function test_bashdep_classify_dep_rejects_empty_sha_annotation() {
+  BASHDEP_DIR=lib BASHDEP_DEV_DIR=lib/dev BASHDEP_DEV_SUFFIX=@dev
+  bashdep::_classify_dep "https://example.com/foo#sha256=" 2>/dev/null
+  assert_general_error
+}
+
+function test_bashdep_classify_dep_rejects_non_hex_sha_annotation() {
+  BASHDEP_DIR=lib BASHDEP_DEV_DIR=lib/dev BASHDEP_DEV_SUFFIX=@dev
+  bashdep::_classify_dep "https://example.com/foo#sha256=xyz" 2>/dev/null
+  assert_general_error
+}
+
 function test_bashdep_resolve_jobs_accepts_positive_integer() {
   BASHDEP_JOBS=8
   assert_equals "8" "$(bashdep::_resolve_jobs)"
@@ -771,6 +783,16 @@ function test_bashdep_install_rejects_bad_checksum_annotation() {
   # shellcheck disable=SC2016
   mock curl 'printf "hello\n" > "$3"'
   bashdep::install "https://example.com/tool#sha256=wrong" >/dev/null 2>&1
+  assert_equals 1 "$?"
+  assert_file_not_exists "$TEST_DIR/tool"
+}
+
+function test_bashdep_install_rejects_empty_checksum_annotation() {
+  BASHDEP_DIR="$TEST_DIR"
+  BASHDEP_JOBS=1
+  # shellcheck disable=SC2016
+  mock curl 'printf "hello\n" > "$3"'
+  bashdep::install "https://example.com/tool#sha256=" >/dev/null 2>&1
   assert_equals 1 "$?"
   assert_file_not_exists "$TEST_DIR/tool"
 }


### PR DESCRIPTION
Follow-up to the opt-in checksum feature (#38), flagged by the weak-typing audit as a deferred footgun.

A present-but-empty pin — `https://example.com/tool#sha256=` — set `BASHDEP_DEP_SHA=""`, which `download_url` reads as *no pin* and **silently skips verification** the caller explicitly requested. `_classify_dep` now validates the annotation: empty or non-hex → error + non-zero (propagated by `_install_one`), so a malformed pin fails **before download** instead of installing unverified. (Non-hex previously fail-safed at the mismatch stage; now it's rejected earlier, and empty is caught too.)

## Test plan
- [x] Suite green: 219 tests / 313 assertions (+3): classify rejects empty + non-hex, install rejects empty annotation
- [x] Existing `install_rejects_bad_checksum_annotation` still passes (now rejected at classify — rc 1, no file)
- [x] Valid hex annotations (incl. the parse tests' short hex fixtures) unaffected
- [x] `make sa` + `make lint` clean; behavior.md + CHANGELOG (unreleased checksum bullet) updated