### PR TITLE
docs: surface parallel installs, checksums, completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,14 @@ chmod +x lib/bashdep
 ```
 
 **2. Declare your dependencies in a `.bashdep` file** (one URL per
-line; `#` comments allowed; `@dev` suffix routes to `lib/dev/`):
+line; `#` comments allowed; `@dev` suffix routes to `lib/dev/`;
+optional `#sha256=<hex>` verifies the download):
 
 ```
 https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
 https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
 https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh@dev
+https://example.com/pinned.sh#sha256=e3b0c44298fc1c149afbf4c8996fb924...
 ```
 
 **3. Install:**
@@ -93,19 +95,25 @@ names not found. See [Behavior](docs/behavior.md#error-handling).
 ## Why bashdep?
 
 - **Idempotent installs** via per-directory `.bashdep.lock`.
+- **Parallel downloads** — dependencies fetch concurrently (tune with
+  `BASHDEP_JOBS`, default 4; `BASHDEP_JOBS=1` for sequential).
+- **Optional integrity checks** — pin a dependency with `#sha256=<hex>`
+  and bashdep verifies the download before recording it.
 - **Dev/prod separation** via the `@dev` URL suffix (`lib/` vs `lib/dev/`).
+- **`curl` or `wget`** — uses whichever is installed.
 - **File-driven, array-driven, or CLI** — `install_from`, `install`, or
-  `./lib/bashdep <command>`.
+  `./lib/bashdep <command>` (with `bash`/`zsh` tab completion).
 - **Lifecycle commands** — `list`, `uninstall`, `clean`, `doctor`,
-  `self_update`.
+  `self_update`, `completion`.
 - **Modes** — `force`, `dry-run`, `silent`, `verbose`.
 
 ## Documentation
 
-- [**API reference**](docs/api.md) — `install`, `install_from`, `setup`,
-  `list`, `uninstall`, `clean`, `doctor`, `self_update`, `version`.
+- [**API reference**](docs/api.md) — the CLI plus `install`,
+  `install_from`, `setup`, `list`, `uninstall`, `clean`, `doctor`,
+  `self_update`, `completion`, `version`.
 - [**Behavior**](docs/behavior.md) — lockfile rules, dev dependencies,
-  error handling.
+  checksum verification, parallel downloads, error handling.
 - [**Releasing**](docs/releasing.md) — how maintainers cut a new tagged
   release with `release.sh`.
 - [**Contributing**](.github/CONTRIBUTING.md) — project layout, test
@@ -115,7 +123,8 @@ names not found. See [Behavior](docs/behavior.md#error-handling).
 
 ```bash
 make deps              # Install bashunit (test runner)
-make test              # Run the suite
+make check             # Full gate: test + ShellCheck + editorconfig
+make test              # Run the suite (BASHUNIT_FLAGS=--simple for quiet)
 make sa                # ShellCheck
 make lint              # editorconfig-checker
 make pre_commit/install

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,7 @@ dev-dependency routing, and error semantics see [Behavior](behavior.md).
 - [`bashdep::self_update`](#bashdepself_update)
 - [`bashdep::setup`](#bashdepsetup)
 - [`bashdep::list`](#bashdeplist)
+- [`bashdep::completion`](#bashdepcompletion)
 - [`bashdep::version`](#bashdepversion)
 
 ## CLI
@@ -63,8 +64,10 @@ bashdep::install "${DEPENDENCIES[@]}"
 Downloads run in parallel, up to `BASHDEP_JOBS` at a time (default `4`).
 Set `BASHDEP_JOBS=1` for sequential downloads. `BASHDEP_JOBS` must be a
 non-negative integer; any other value is rejected with a warning and the
-default of `4` is used. Returns the number of failed downloads (0 on
-success, capped at 255).
+default of `4` is used. Append `#sha256=<hex>` to a URL to verify the
+download (see [Checksum verification](behavior.md#checksum-verification-opt-in)).
+Prints an `installed X, skipped Y, failed Z` summary (unless `silent`)
+and returns the number of failed downloads (0 on success, capped at 255).
 
 ## `bashdep::install_from`
 
@@ -190,10 +193,19 @@ lib/dev/dumper.sh	https://github.com/Chemaclass/bash-dumper/releases/download/0.
 
 Pipe into `awk` / `cut` for audit and diff tooling.
 
+## `bashdep::completion`
+
+Print a shell completion script for the CLI commands and flags. Accepts
+`bash` (default) or `zsh`; returns `1` for any other shell.
+
+```bash
+source <(bashdep completion bash)   # or: bashdep completion zsh
+```
+
 ## `bashdep::version`
 
 Print the bashdep version.
 
 ```bash
-bashdep::version  # e.g. 0.4.2
+bashdep::version  # e.g. 0.6.0
 ```

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -6,6 +6,7 @@ skip. For function signatures and the CLI see the
 
 - [Lockfile and idempotency](#lockfile-and-idempotency)
 - [Dev dependencies](#dev-dependencies)
+- [Checksum verification](#checksum-verification-opt-in)
 - [Error handling](#error-handling)
 
 ## Lockfile and idempotency
@@ -78,9 +79,8 @@ verified (the default).
   non-negative integer; a non-numeric or otherwise invalid value is
   rejected with a warning and the default of `4` is used. It continues
   past failed downloads and returns the failure count (capped at 255).
-  Lockfile
-  writes are batched into a single rewrite per directory after all
-  downloads finish, so concurrency never corrupts the lockfile.
+  Lockfile writes are batched into a single rewrite per directory after
+  all downloads finish, so concurrency never corrupts the lockfile.
 - `bashdep::install_from` returns `1` if the file (default: `.bashdep`)
   is missing or unreadable.
 - `bashdep::setup` returns `1` on unknown params or non-boolean values


### PR DESCRIPTION
Brings README + API docs up to date with everything added since 0.6.0 that wasn't yet reflected in the front-door docs.

- **README**: `#sha256=` pin in the `.bashdep` example; **Why bashdep?** now lists parallel downloads (`BASHDEP_JOBS`), optional integrity checks, curl-or-wget, and tab completion; **Development** adds `make check` and the `BASHUNIT_FLAGS=--simple` quiet option; doc index mentions `completion` + checksum/parallel.
- **api.md**: `install` documents the `#sha256=` annotation (linked to behavior.md) and the `installed X, skipped Y, failed Z` summary; new `bashdep::completion` section; refreshed the stale `0.4.2` version example → `0.6.0`.
- **behavior.md**: Checksum section added to the TOC; fixed an awkward line wrap.

## Test plan
- [x] `ec` clean on all edited docs; no stale `tests.yml`/`static_analysis.yml`/`linter.yml` refs remain
- [x] Cross-checked every documented feature against the current code (parallel/JOBS, checksum incl. empty/non-hex rejection, completion, --version, summary, wget, doctor malformed)
- [x] Docs only — no code change