### PR TITLE
docs: document model gotchas and drop stale version example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ names not found. See [Behavior](docs/behavior.md#error-handling).
   `install_from`, `setup`, `list`, `uninstall`, `clean`, `doctor`,
   `self_update`, `completion`, `version`.
 - [**Behavior**](docs/behavior.md) — lockfile rules, dev dependencies,
-  checksum verification, parallel downloads, error handling.
+  checksum verification, parallel downloads, error handling, gotchas.
 - [**Releasing**](docs/releasing.md) — how maintainers cut a new tagged
   release with `release.sh`.
 - [**Contributing**](.github/CONTRIBUTING.md) — project layout, test

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
 # Documentation
 
 - [API reference](api.md) — every public `bashdep::*` function.
-- [Behavior](behavior.md) — lockfile rules, dev dependencies, error
-  handling.
+- [Behavior](behavior.md) — lockfile rules, dev dependencies, checksum
+  verification, parallel downloads, error handling, gotchas.
 - [Releasing](releasing.md) — how to cut a new tagged release with
   `release.sh`.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -207,5 +207,5 @@ source <(bashdep completion bash)   # or: bashdep completion zsh
 Print the bashdep version.
 
 ```bash
-bashdep::version  # e.g. 0.6.0
+bashdep::version  # prints the version string, e.g. 0.7.0
 ```

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -8,6 +8,7 @@ skip. For function signatures and the CLI see the
 - [Dev dependencies](#dev-dependencies)
 - [Checksum verification](#checksum-verification-opt-in)
 - [Error handling](#error-handling)
+- [Gotchas](#gotchas)
 
 ## Lockfile and idempotency
 
@@ -102,3 +103,21 @@ set -euo pipefail
 source lib/bashdep
 bashdep::install_from .bashdep || exit $?
 ```
+
+## Gotchas
+
+Known boundaries of the flat, URL-driven model — by design, not bugs:
+
+- **A dependency's identity is its filename** — the last path segment of
+  the URL. Two URLs ending in the same basename (`.../v1/util.sh` and
+  `.../v2/util.sh`) resolve to the same file in the same directory: the
+  second overwrites the first and the lockfile keeps a single entry.
+  Disambiguate by routing one to `@dev`, pointing it at another `dir`, or
+  renaming upstream.
+- **The lockfile pins the source URL, not a checksum.** Idempotency and
+  `doctor` drift detection compare URLs; integrity is enforced only when
+  you add an explicit `#sha256=` annotation, which is re-checked on every
+  download.
+- **No transitive resolution.** bashdep installs exactly the URLs you
+  list — a dependency cannot declare its own dependencies. List the full
+  set yourself.


### PR DESCRIPTION
## What

Surgical docs pass — no prose churn.

- **`docs/behavior.md`** — new **Gotchas** section (+ TOC entry) documenting three real boundaries of the flat, URL-driven model, framed as by-design:
  - a dependency's identity is its filename → same-basename URLs collide in a directory
  - the lockfile pins the source URL, not a checksum (integrity is opt-in via `#sha256=`)
  - no transitive resolution — list the full set yourself
- **`docs/api.md`** — dropped the hardcoded `0.6.0` from the `bashdep::version` example so it stops drifting every release.
- **`docs/README.md`** — index Behavior line now lists checksum + parallel + gotchas (was only lockfile/dev-deps/error handling).
- **`README.md`** — matched the Behavior blurb for consistency.

## Why

The gotchas are the questions a user hits first (filename collisions, "does the lock verify integrity?"). Documenting them up front beats a surprise. The version example was already stale (`0.6.0` vs shipped `0.7.0`).

## Test plan

Docs-only. `make lint` (editorconfig) green; all edited lines within the 100-char cap.