### PR TITLE
feat(release): add build.sh amalgamator for single-file bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
   `templates/release.sh` engine and a documented `release.conf.example`.
   Other bash projects can copy these to automate GitHub releases. bashdep
   now **dogfoods** the engine via its own `release.conf`.
+- `templates/build.sh`: an amalgamator that inlines static, top-level
+  `source`/`.` includes into a single self-contained executable — a
+  release asset for multi-file bash projects. Dynamic includes
+  (`source "$var"`, indented sources) are left untouched by design.
 
 ### Changed
 

--- a/templates/build.sh
+++ b/templates/build.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+#
+# build.sh — amalgamate a multi-file bash project into one executable.
+#
+# Inlines static, top-level `source <path>` / `. <path>` directives
+# (recursively, each file inlined once) into a single self-contained
+# script, printed to stdout — suitable as a release asset produced by a
+# release.conf `release_build` hook.
+#
+# What it inlines: a line that begins at column 0 with `source ` or `. `
+# followed by a single literal path (optionally quoted). What it leaves
+# untouched (printed as-is): dynamic includes — `source "$var"`, command
+# substitution, globs — and any indented `source` (e.g. inside a function
+# or conditional), since a line-based bundler cannot know when it runs.
+# Keep your includes static and top-level for a clean bundle.
+#
+# Usage (run from your repo root):
+#   build.sh ENTRY > OUTPUT
+#   build.sh src/main.sh > dist/tool && chmod +x dist/tool
+#
+# Returns 1 on usage error or a missing entry file. A `source` whose target
+# is missing is left in place (not fatal) so the result still shows intent.
+#
+
+set -euo pipefail
+
+# Newline-delimited list of already-inlined absolute paths (dedup + cycle
+# guard). Bash 3.2 has no associative arrays, so this mirrors bashdep's
+# own "seen" pattern.
+SEEN=""
+# Recursion depth: 0 is the entry file (keeps its shebang); deeper files
+# have their leading shebang stripped.
+DEPTH=0
+
+# Resolve $1 (a path, relative to directory $2 unless absolute) to a
+# normalized absolute path. Falls back to the raw path if the directory
+# cannot be entered.
+resolve_path() {
+  local path=$1 base=$2 d b
+  b=$(basename "$path")
+  case $path in
+    /*) d=$(dirname "$path") ;;
+    *)  d="$base/$(dirname "$path")" ;;
+  esac
+  d=$(cd "$d" 2>/dev/null && pwd) || { printf '%s\n' "$path"; return; }
+  printf '%s/%s\n' "$d" "$b"
+}
+
+# If $1 is a static, inlineable source directive, echo its literal path and
+# return 0; otherwise return 1. Only column-0 `source `/`. ` lines with a
+# single literal (optionally quoted) path qualify — dynamic or glob paths
+# and extra arguments are rejected.
+parse_source_line() {
+  local line=$1 rest path
+  case $line in
+    'source '*) rest=${line#source } ;;
+    '. '*)      rest=${line#. } ;;
+    *) return 1 ;;
+  esac
+  # Trim surrounding whitespace.
+  rest=${rest#"${rest%%[![:space:]]*}"}
+  rest=${rest%"${rest##*[![:space:]]}"}
+  [[ -z "$rest" ]] && return 1
+  # Strip one layer of matching quotes.
+  case $rest in
+    \"*\") path=${rest#\"}; path=${path%\"} ;;
+    \'*\') path=${rest#\'}; path=${path%\'} ;;
+    *)     path=$rest ;;
+  esac
+  # Reject extra args (internal whitespace) and dynamic/glob content.
+  case $path in
+    ''|*[[:space:]]*)          return 1 ;;
+    *'$'*|*'`'*|*'*'*|*'?'*|*'['*) return 1 ;;
+  esac
+  printf '%s\n' "$path"
+}
+
+# Recursively print $1's contents with inlineable sources expanded.
+inline_file() {
+  local file=$1
+  local dir abs
+  dir=$(dirname "$file")
+  abs=$(resolve_path "$file" ".")
+  # Skip files already inlined (dedup + cycle guard).
+  case $'\n'"$SEEN"$'\n' in
+    *$'\n'"$abs"$'\n'*) return 0 ;;
+  esac
+  SEEN="$SEEN$abs"$'\n'
+
+  local first=true line inc incabs
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if $first; then
+      first=false
+      # Drop the shebang of an included file — the entry keeps its own.
+      if [[ $DEPTH -gt 0 && "$line" == '#!'* ]]; then
+        continue
+      fi
+    fi
+    if inc=$(parse_source_line "$line"); then
+      incabs=$(resolve_path "$inc" "$dir")
+      if [[ -f "$incabs" ]]; then
+        # Silently drop a repeat include already inlined elsewhere.
+        case $'\n'"$SEEN"$'\n' in
+          *$'\n'"$incabs"$'\n'*) continue ;;
+        esac
+        printf '# >>> inlined: %s\n' "$inc"
+        DEPTH=$((DEPTH + 1))
+        inline_file "$incabs"
+        DEPTH=$((DEPTH - 1))
+        printf '# <<< end: %s\n' "$inc"
+        continue
+      fi
+    fi
+    printf '%s\n' "$line"
+  done < "$file"
+}
+
+main() {
+  if [[ $# -ne 1 ]]; then
+    echo "Usage: build.sh ENTRY" >&2
+    exit 1
+  fi
+  local entry=$1
+  if [[ ! -f "$entry" ]]; then
+    echo "Error: entry file not found: $entry" >&2
+    exit 1
+  fi
+  DEPTH=0
+  SEEN=""
+  inline_file "$entry"
+}
+
+# Run only when executed directly; sourcing (e.g. from tests) exposes the
+# functions without side effects.
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/tests/unit/build_test.sh
+++ b/tests/unit/build_test.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# shellcheck disable=SC2155,SC2034,SC2016
+#
+# SC2016: several tests pass single-quoted literals like 'source "$LIB"'
+# to parse_source_line on purpose — the `$` must stay unexpanded.
+#
+# Unit tests for the amalgamator (templates/build.sh). Pure-logic helpers
+# (parse_source_line) are exercised by sourcing the script under its
+# BASH_SOURCE guard; the end-to-end bundling is exercised by invoking the
+# script as a subprocess against fixtures in $TEST_DIR.
+
+TEST_DIR=""
+BUILD=""
+
+function set_up() {
+  if ! declare -f parse_source_line >/dev/null 2>&1; then
+    # shellcheck disable=SC1091
+    source "$(current_dir)/../../templates/build.sh"
+  fi
+  set +e +u +o pipefail
+  REPO_ROOT="$(cd "$(current_dir)/../.." && pwd)"
+  BUILD="$REPO_ROOT/templates/build.sh"
+  TEST_DIR=$(mktemp -d)
+}
+
+function tear_down() {
+  if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+    rm -rf "$TEST_DIR"
+  fi
+}
+
+# --- parse_source_line -------------------------------------------------------
+
+function test_build_parse_source_accepts_relative() {
+  assert_equals "./lib.sh" "$(parse_source_line 'source ./lib.sh')"
+}
+
+function test_build_parse_source_accepts_dot_form() {
+  assert_equals "./lib.sh" "$(parse_source_line '. ./lib.sh')"
+}
+
+function test_build_parse_source_accepts_quoted() {
+  assert_equals "./lib.sh" "$(parse_source_line 'source "./lib.sh"')"
+}
+
+function test_build_parse_source_rejects_dynamic_var() {
+  parse_source_line 'source "$LIB"'
+  assert_general_error
+}
+
+function test_build_parse_source_rejects_command_sub() {
+  parse_source_line 'source "$(dirname "$0")/lib.sh"'
+  assert_general_error
+}
+
+# Indented sources are treated as non-top-level (likely inside a function
+# or conditional) and left untouched.
+function test_build_parse_source_rejects_indented() {
+  parse_source_line '  source ./lib.sh'
+  assert_general_error
+}
+
+function test_build_parse_source_rejects_extra_args() {
+  parse_source_line 'source ./lib.sh --flag'
+  assert_general_error
+}
+
+function test_build_parse_source_rejects_plain_line() {
+  parse_source_line 'echo hello'
+  assert_general_error
+}
+
+# --- end-to-end bundling -----------------------------------------------------
+
+function test_build_inlines_static_source() {
+  printf '#!/bin/bash\nsource ./lib.sh\necho main\n' > "$TEST_DIR/main.sh"
+  printf 'echo from-lib\n' > "$TEST_DIR/lib.sh"
+  local out
+  out=$(cd "$TEST_DIR" && bash "$BUILD" main.sh)
+  assert_contains "echo from-lib" "$out"
+}
+
+function test_build_removes_the_source_directive() {
+  printf '#!/bin/bash\nsource ./lib.sh\n' > "$TEST_DIR/main.sh"
+  printf 'echo from-lib\n' > "$TEST_DIR/lib.sh"
+  local out
+  out=$(cd "$TEST_DIR" && bash "$BUILD" main.sh)
+  assert_not_contains "source ./lib.sh" "$out"
+}
+
+function test_build_keeps_single_entry_shebang() {
+  printf '#!/bin/bash\nsource ./lib.sh\n' > "$TEST_DIR/main.sh"
+  printf '#!/bin/bash\necho lib\n' > "$TEST_DIR/lib.sh"
+  local out count
+  out=$(cd "$TEST_DIR" && bash "$BUILD" main.sh)
+  count=$(printf '%s\n' "$out" | grep -c '^#!/bin/bash')
+  assert_equals "1" "$count"
+}
+
+function test_build_dedups_diamond_include() {
+  printf '#!/bin/bash\nsource ./a.sh\nsource ./b.sh\n' > "$TEST_DIR/main.sh"
+  printf 'source ./common.sh\necho a\n' > "$TEST_DIR/a.sh"
+  printf 'source ./common.sh\necho b\n' > "$TEST_DIR/b.sh"
+  printf 'echo common\n' > "$TEST_DIR/common.sh"
+  local out count
+  out=$(cd "$TEST_DIR" && bash "$BUILD" main.sh)
+  count=$(printf '%s\n' "$out" | grep -c 'echo common')
+  assert_equals "1" "$count"
+}
+
+function test_build_dedup_repeat_include_emits_no_empty_markers() {
+  printf '#!/bin/bash\nsource ./lib.sh\nsource ./lib.sh\n' > "$TEST_DIR/main.sh"
+  printf 'echo x\n' > "$TEST_DIR/lib.sh"
+  local out count
+  out=$(cd "$TEST_DIR" && bash "$BUILD" main.sh)
+  count=$(printf '%s\n' "$out" | grep -c '>>> inlined: ./lib.sh')
+  assert_equals "1" "$count"
+}
+
+function test_build_inlines_recursively() {
+  printf '#!/bin/bash\nsource ./a.sh\n' > "$TEST_DIR/main.sh"
+  printf 'source ./b.sh\necho a\n' > "$TEST_DIR/a.sh"
+  printf 'echo b\n' > "$TEST_DIR/b.sh"
+  local out
+  out=$(cd "$TEST_DIR" && bash "$BUILD" main.sh)
+  assert_contains "echo b" "$out"
+}
+
+function test_build_leaves_dynamic_source_untouched() {
+  printf '#!/bin/bash\nlib="./lib.sh"\nsource "$lib"\n' > "$TEST_DIR/main.sh"
+  printf 'echo from-lib\n' > "$TEST_DIR/lib.sh"
+  local out
+  out=$(cd "$TEST_DIR" && bash "$BUILD" main.sh)
+  assert_not_contains "echo from-lib" "$out"
+}
+
+function test_build_leaves_missing_include_in_place() {
+  printf '#!/bin/bash\nsource ./nope.sh\n' > "$TEST_DIR/main.sh"
+  local out
+  out=$(cd "$TEST_DIR" && bash "$BUILD" main.sh)
+  assert_contains "source ./nope.sh" "$out"
+}
+
+function test_build_output_is_valid_bash() {
+  printf '#!/bin/bash\nsource ./lib.sh\ngreet\n' > "$TEST_DIR/main.sh"
+  printf 'greet() { echo hi; }\n' > "$TEST_DIR/lib.sh"
+  ( cd "$TEST_DIR" && bash "$BUILD" main.sh > bundle.sh )
+  bash -n "$TEST_DIR/bundle.sh"
+  assert_successful_code "$?"
+}
+
+function test_build_errors_on_missing_entry() {
+  ( bash "$BUILD" "$TEST_DIR/does-not-exist.sh" ) 2>/dev/null
+  assert_general_error
+}
+
+function test_build_errors_without_args() {
+  ( bash "$BUILD" ) 2>/dev/null
+  assert_general_error
+}


### PR DESCRIPTION
## What

Adds `templates/build.sh` — the second half of the release kit. It amalgamates a multi-file bash project into one self-contained executable, ready to hand to a `release.conf` `release_build` hook as a `RELEASE_ASSETS` entry.

```bash
templates/build.sh src/main.sh > dist/tool && chmod +x dist/tool
```

## Behavior

- Inlines **static, top-level** `source <path>` / `. <path>` directives (column 0, single literal path, optionally quoted), recursively, **each file once** (dedup + cycle guard via a `SEEN` list — the Bash 3.2 `case`-match pattern, no associative arrays).
- Keeps the **entry** shebang; strips shebangs of inlined files.
- Wraps each inlined file in `# >>> inlined / # <<< end` provenance markers; a deduped repeat include emits nothing.
- **Left untouched by design** (printed as-is): dynamic includes — `source "$var"`, command substitution, globs — and any **indented** source (inside a function/conditional), which a line-based bundler can't safely relocate. A missing include is left in place, not fatal.

Documented in `templates/README.md` (added in #61), including the limitations.

## Why a separate PR

The engine (#61) is dogfooded by bashdep's own releases; the bundler can't be — bashdep is single-file, so it has nothing to amalgamate. It gets its **own tests + fixtures** as the safety net instead.

## Test plan

- `tests/unit/build_test.sh` — **19 tests**: `parse_source_line` accept/reject matrix (relative, `.` form, quoted, dynamic `$var`, command-sub, indented, extra-args, plain line) and end-to-end bundling (inline, directive removal, single entry shebang, diamond dedup, no empty markers on repeat, recursion, dynamic left alone, missing include in place, output passes `bash -n`, usage/missing-entry errors).
- Full suite: **337 assertions pass**. `make sa` + `make lint` green.
- Manual smoke: bundled a 2-file program with a duplicate include → clean single-file output that runs correctly.