### PR TITLE
docs(changelog): drop empty section headings for consistent history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,10 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ## [Unreleased]
 
-### Added
-
 ### Changed
 
-### Fixed
+- CHANGELOG housekeeping: dropped empty section headings from released
+  entries for a cleaner, consistent history.
 
 ## [0.8.0] - 2026-07-24
 
@@ -29,8 +28,6 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
   `templates/release.sh` configured by `release.conf`; behavior and flags
   are unchanged. Project-specific bits (version read/write, gate, assets,
   release notes) live in `release.conf`.
-
-### Fixed
 
 ## [0.7.0] - 2026-07-23
 
@@ -61,8 +58,6 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 - Downloads pass `--` before the URL (curl and wget) so a URL beginning
   with `-` can never be misparsed as an option.
-
-### Fixed
 
 ## [0.6.0] - 2026-07-22
 


### PR DESCRIPTION
## What

De-noises the CHANGELOG so entries are consistent.

- Removed the empty `### Fixed` heading carried by **0.8.0** and **0.7.0** (neither shipped a fix). 0.5.0 already omitted empty sections — now every entry follows the same Keep-a-Changelog convention (omit empty sections).
- `[Unreleased]` trimmed to only the section it uses.

## Why

The changelog is otherwise well-maintained; the only wart was empty subsection headings on some releases but not others. Consistent history, less scroll noise.

## Test plan

Docs-only. `make lint` (editorconfig) green.

Prep for cutting a housekeeping patch release next.