### PR TITLE
chore(deps): update bashunit to 0.45.0, pin CI actions, add --jobs

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -97,6 +97,24 @@ they keep hardcoded `/tmp/test_<name>` paths. Do **not** migrate them to
 - No real `release.sh` invocations from tests
 - Tests must be safe to run in any order
 
+## The `mock` / `unmock` helpers
+
+`mock` and `unmock` are defined by **this repo** in `tests/bootstrap.sh`,
+not by bashunit. bashunit >= 0.40 moved its doubles under
+`bashunit::mock` and made the multi-argument form append `"$@"` to the
+body, which cannot express a mock body that reads positional arguments —
+the shape this suite uses everywhere:
+
+```bash
+mock curl 'touch "$3"'          # body sees the real call's arguments
+mock bashdep::download_url "return 1"
+mock curl <<< "payload"         # no body: echo stdin instead
+```
+
+Each bashunit test runs in its own subshell, so mocks cannot leak between
+tests and need no registry — `unmock` is only for restoring a real
+command *within* a single test.
+
 ## Mocking `curl`
 
 bashdep's only network surface is `curl`. To test install paths without

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -44,12 +44,12 @@ jobs:
           - macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: "Cache bashunit"
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: lib
           key: bashunit-${{ runner.os }}-${{ hashFiles('install-dependencies.sh') }}
@@ -72,12 +72,12 @@ jobs:
           - macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@2.0.0
         env:
           SHELLCHECK_OPTS: -e SC1091 -e SC2155
 
@@ -86,12 +86,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Editorconfig Linter
-        uses: editorconfig-checker/action-editorconfig-checker@main
+        uses: editorconfig-checker/action-editorconfig-checker@v2.2.0
 
       - name: Run Linter
         run: editorconfig-checker

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,18 +26,18 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
         with:
           enablement: true
 
       - name: Upload site artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ vendor/
 
 # release build output
 dist/
+
+# bashunit run state (last-failed cache)
+.bashunit/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,32 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Added
 
+- Concurrency is now configurable without touching the environment:
+  `bashdep::setup jobs=N` and the CLI's `--jobs=N` both set
+  `BASHDEP_JOBS`. The flag is listed in `--help` and offered by the
+  `bash`/`zsh` completion scripts. Validation is unchanged — a
+  non-integer warns and falls back to `4` when `install` runs.
+
 ### Changed
+
+- `bashdep::_sha256` resolves `shasum`/`sha256sum` once per run (cached
+  in `BASHDEP_SHA_TOOL`) instead of re-probing on every call, mirroring
+  how `BASHDEP_DOWNLOADER` already pins `curl`/`wget` for a whole run, so
+  every checksum in a run is computed by the same tool. It also slices
+  the digest with parameter expansion, which keeps `awk` out of that
+  path. Measured as performance-neutral (150 digests: 1.51s before and
+  after) — this is a consistency change, not a speedup.
+- Development dependency: bashunit `0.17.0` → `0.45.0`, which cuts the
+  suite's runtime from ~27s to ~2.5s. bashunit moved its doubles to
+  `bashunit::mock` and changed the multi-argument form to append `"$@"`
+  to the mock body, which cannot express a body that reads positional
+  arguments; `tests/bootstrap.sh` now defines the `mock`/`unmock` helpers
+  the suite relies on.
+- CI actions pinned and bumped: `checkout@v7`, `cache@v6`,
+  `paths-filter@v4`, `configure-pages@v6`, `upload-pages-artifact@v5`,
+  `deploy-pages@v5`, and the two previously floating refs
+  (`action-shellcheck@master`, `action-editorconfig-checker@main`) now
+  pin to `2.0.0` and `v2.2.0` for reproducible runs.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,8 @@ names not found. See [Behavior](docs/behavior.md#error-handling).
 
 - **Idempotent installs** via per-directory `.bashdep.lock`.
 - **Parallel downloads** — dependencies fetch concurrently (tune with
-  `BASHDEP_JOBS`, default 4; `BASHDEP_JOBS=1` for sequential).
+  `--jobs=N`, `bashdep::setup jobs=N`, or `BASHDEP_JOBS`; default 4,
+  `1` for sequential).
 - **Optional integrity checks** — pin a dependency with `#sha256=<hex>`
   and bashdep verifies the download before recording it.
 - **Dev/prod separation** via the `@dev` URL suffix (`lib/` vs `lib/dev/`).

--- a/bashdep
+++ b/bashdep
@@ -12,6 +12,7 @@ BASHDEP_FORCE=false
 BASHDEP_DRY_RUN=false
 BASHDEP_VERBOSE=false
 BASHDEP_DOWNLOADER=""
+BASHDEP_SHA_TOOL=""
 BASHDEP_LOCK_DEFER=false
 BASHDEP_LOCK_PENDING=()
 BASHDEP_SELF_URL_TEMPLATE="${BASHDEP_SELF_URL_TEMPLATE:-https://raw.githubusercontent.com/Chemaclass/bashdep/%s/bashdep}"
@@ -69,11 +70,14 @@ function bashdep::self_update() {
 # Configure bashdep behavior.
 #
 # Usage:
-#   bashdep::setup [dir=DIR] [dev-dir=DEV_DIR] [silent=BOOL] [force=BOOL] [dry-run=BOOL]
+#   bashdep::setup [dir=DIR] [dev-dir=DEV_DIR] [jobs=N] [silent=BOOL] [force=BOOL] [dry-run=BOOL]
 #
 # Parameters:
 #       dir    - Default destination directory (default: lib).
 #   dev-dir    - Development destination directory (default: lib/dev).
+#   jobs       - Concurrent downloads, i.e. BASHDEP_JOBS (default: 4;
+#                1 for sequential). Validated when install runs: a
+#                non-integer warns and falls back to 4.
 #   silent     - Suppress progress output (default: false).
 #   force      - Re-download dependencies even if they already exist (default: false).
 #   dry-run    - Preview actions without downloading or writing the lockfile (default: false).
@@ -88,6 +92,7 @@ function bashdep::setup() {
     case $param in
       dir=*)       BASHDEP_DIR="${param#*=}"        ;;
       dev-dir=*)   BASHDEP_DEV_DIR="${param#*=}"    ;;
+      jobs=*)      BASHDEP_JOBS="${param#*=}"       ;;
       silent=*)    bashdep::_set_bool BASHDEP_SILENT  "${param#*=}" silent  || return 1 ;;
       force=*)     bashdep::_set_bool BASHDEP_FORCE   "${param#*=}" force   || return 1 ;;
       dry-run=*)   bashdep::_set_bool BASHDEP_DRY_RUN "${param#*=}" dry-run || return 1 ;;
@@ -498,16 +503,31 @@ function bashdep::_has_wget() { command -v wget >/dev/null 2>&1; }
 
 # Internal: print the SHA-256 hex of a file, portable across macOS
 # (shasum) and Linux (sha256sum). Returns 1 if neither tool is available.
+# The choice is resolved once per run (cached in BASHDEP_SHA_TOOL), mirroring
+# BASHDEP_DOWNLOADER: a batch install does not re-probe, and every checksum in
+# a run is computed by the same tool. The hex is cut with parameter expansion
+# so the path needs no awk.
 function bashdep::_sha256() {
-  local file=$1
-  if command -v shasum >/dev/null 2>&1; then
-    shasum -a 256 "$file" | awk '{print $1}'
-  elif command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "$file" | awk '{print $1}'
-  else
-    echo "Error: need 'shasum' or 'sha256sum' to verify checksums." >&2
-    return 1
+  local file=$1 line
+  if [[ -z "$BASHDEP_SHA_TOOL" ]]; then
+    if command -v shasum >/dev/null 2>&1; then
+      BASHDEP_SHA_TOOL=shasum
+    elif command -v sha256sum >/dev/null 2>&1; then
+      BASHDEP_SHA_TOOL=sha256sum
+    else
+      BASHDEP_SHA_TOOL=none
+    fi
   fi
+
+  case $BASHDEP_SHA_TOOL in
+    shasum)    line=$(shasum -a 256 "$file") || return 1 ;;
+    sha256sum) line=$(sha256sum "$file") || return 1 ;;
+    *)
+      echo "Error: need 'shasum' or 'sha256sum' to verify checksums." >&2
+      return 1
+      ;;
+  esac
+  printf '%s\n' "${line%% *}"
 }
 
 # Internal: download $1 (url) into $2 (output path). Prefers curl and falls
@@ -587,6 +607,11 @@ function bashdep::_set_bool() {
 
 # Internal: read URL recorded in lockfile for a given filename.
 # Prints the URL on stdout (empty if absent or lockfile missing).
+#
+# This stays an awk pass rather than a pure-bash scan of the whole file:
+# bash pattern matching re-scans the lockfile on every lookup, which turns
+# an N-dependency install quadratic and overtakes the fork it saves at
+# roughly 50 entries.
 function bashdep::_lock_get() {
   local lock_file=$1 file_name=$2
   [[ -f "$lock_file" ]] || return 0
@@ -725,6 +750,7 @@ Options:
   --dir=DIR             Destination directory (default: lib)
   --dev-dir=DIR         Dev destination directory (default: lib/dev)
   --file=FILE           Dependency file for install (default: .bashdep)
+  --jobs=N              Concurrent downloads (default: 4, 1 = sequential)
   --force               Re-download even when already installed
   --dry-run             Preview actions without touching disk
   --silent              Suppress informational output
@@ -740,7 +766,7 @@ EOF
 function bashdep::completion() {
   local shell=${1:-bash}
   local commands="install list uninstall clean doctor self-update completion version help"
-  local flags="--dir --dev-dir --file --force --dry-run --silent --verbose --version --help"
+  local flags="--dir --dev-dir --file --jobs --force --dry-run --silent --verbose --version --help"
   case $shell in
     bash)
       cat <<EOF
@@ -796,6 +822,7 @@ function bashdep::main() {
       --verbose)   BASHDEP_VERBOSE=true ;;
       --dir=*)     BASHDEP_DIR="${arg#*=}" ;;
       --dev-dir=*) BASHDEP_DEV_DIR="${arg#*=}" ;;
+      --jobs=*)    BASHDEP_JOBS="${arg#*=}" ;;
       --file=*)    dep_file="${arg#*=}" ;;
       -*)
         echo "Error: Unknown option '$arg'" >&2

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,9 +40,9 @@ source <(bashdep completion bash)
 ```
 
 Options map 1:1 to [`bashdep::setup`](#bashdepsetup) parameters:
-`--dir=DIR`, `--dev-dir=DIR`, `--force`, `--dry-run`, `--silent`,
-`--verbose`. `install` also accepts `--file=FILE` to point at a
-dependency file other than `.bashdep`.
+`--dir=DIR`, `--dev-dir=DIR`, `--jobs=N`, `--force`, `--dry-run`,
+`--silent`, `--verbose`. `install` also accepts `--file=FILE` to point
+at a dependency file other than `.bashdep`.
 
 `--version` prints the version and `-h`/`--help` prints usage. Exit codes
 match the underlying function's return value (e.g. `doctor` exits with
@@ -61,8 +61,9 @@ DEPENDENCIES=(
 bashdep::install "${DEPENDENCIES[@]}"
 ```
 
-Downloads run in parallel, up to `BASHDEP_JOBS` at a time (default `4`).
-Set `BASHDEP_JOBS=1` for sequential downloads. `BASHDEP_JOBS` must be a
+Downloads run in parallel, up to `BASHDEP_JOBS` at a time (default `4`),
+which `bashdep::setup jobs=N` and the CLI's `--jobs=N` also set. Use `1`
+for sequential downloads. `BASHDEP_JOBS` must be a
 non-negative integer; any other value is rejected with a warning and the
 default of `4` is used. Append `#sha256=<hex>` to a URL to verify the
 download (see [Checksum verification](behavior.md#checksum-verification-opt-in)).
@@ -166,6 +167,7 @@ Configure defaults before calling `install`. All parameters are optional.
 | --------- | ------ | --------- | ------------------------------------------------------ |
 | `dir`     | string | `lib`     | Destination for normal dependencies.                   |
 | `dev-dir` | string | `lib/dev` | Destination for dev dependencies (URLs ending `@dev`). |
+| `jobs`    | int    | `4`       | Concurrent downloads (`1` = sequential); sets `BASHDEP_JOBS`. |
 | `silent`  | bool   | `false`   | Suppress progress output.                              |
 | `force`   | bool   | `false`   | Re-download even when the file already exists.         |
 | `dry-run` | bool   | `false`   | Preview actions without writing to disk.               |
@@ -176,7 +178,10 @@ bashdep::setup dir="vendor" dev-dir="src/dev" silent=true force=false
 ```
 
 Invalid values (unknown param, non-boolean for `silent`/`force`) cause
-`setup` to print an error to stderr and return `1`.
+`setup` to print an error to stderr and return `1`. `jobs` is not
+validated here — like the `BASHDEP_JOBS` environment variable it is
+checked when `install` runs, where a non-integer warns and falls back
+to `4`.
 
 ## `bashdep::list`
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -76,7 +76,8 @@ verified (the default).
 ## Error handling
 
 - `bashdep::install` downloads in parallel (up to `BASHDEP_JOBS`, default
-  `4`; set `BASHDEP_JOBS=1` for sequential). `BASHDEP_JOBS` must be a
+  `4`; use `1` for sequential). `BASHDEP_JOBS` is also settable via
+  `bashdep::setup jobs=N` or the CLI's `--jobs=N`. It must be a
   non-negative integer; a non-numeric or otherwise invalid value is
   rejected with a warning and the default of `4` is used. It continues
   past failed downloads and returns the failure count (capped at 255).

--- a/example/demo.sh
+++ b/example/demo.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 source "$(dirname "$0")/../bashdep"
 
 DEPENDENCIES=(
-  "https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit"
+  "https://github.com/TypedDevs/bashunit/releases/download/0.45.0/bashunit"
   "https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr"
   "https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh@dev"
 )

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Pin to the same bashunit version used in CI (.github/workflows/ci.yml).
-BASHUNIT_VERSION="${BASHUNIT_VERSION:-0.17.0}"
+BASHUNIT_VERSION="${BASHUNIT_VERSION:-0.45.0}"
 
 echo "Installing bashunit ${BASHUNIT_VERSION} into lib/..."
 curl -fsSL https://bashunit.typeddevs.com/install.sh | bash -s lib "${BASHUNIT_VERSION}"

--- a/tests/bootstrap.sh
+++ b/tests/bootstrap.sh
@@ -8,3 +8,30 @@ function temp_dir() {
   mkdir -p /tmp/bashunit-tmp && chmod -R 777 /tmp/bashunit-tmp
   mktemp -d --tmpdir="/tmp/bashunit-tmp" "XXXXXXX"
 }
+
+# Replace $1 with a function whose body is the remaining arguments.
+#
+# bashunit >= 0.40 moved its doubles under `bashunit::mock` and made the
+# multi-argument form append `"$@"` to the body, so a mock body that reads
+# positional arguments (`touch "$3"`) can no longer be expressed. The suite
+# leans on that shape heavily, so it keeps its own helper. Each bashunit
+# test runs in its own subshell, so mocks cannot leak between tests and
+# need no registry.
+#
+# With no body, the function echoes stdin instead:
+#   mock curl <<< "payload"
+function mock() {
+  local command=$1
+  shift
+  if [[ $# -gt 0 ]]; then
+    eval "function $command() { $* ; }"
+  else
+    eval "function $command() { echo \"$(cat)\" ; }"
+  fi
+  export -f "${command?}"
+}
+
+# Restore $1 to its real implementation.
+function unmock() {
+  unset -f "$1"
+}

--- a/tests/unit/bashdep_test.sh
+++ b/tests/unit/bashdep_test.sh
@@ -261,6 +261,11 @@ function test_bashdep_setup_persists_dev_dir() {
   assert_equals "custom_dev" "$BASHDEP_DEV_DIR"
 }
 
+function test_bashdep_setup_persists_jobs() {
+  bashdep::setup jobs=8
+  assert_equals "8" "$BASHDEP_JOBS"
+}
+
 function test_bashdep_setup_silent_true_makes_is_silent_truthy() {
   bashdep::setup silent=true
   bashdep::is_silent
@@ -383,6 +388,39 @@ function test_bashdep_lock_get_returns_empty_when_entry_missing() {
   local lock_file="$TEST_DIR/lock"
   printf 'other\thttps://example.com/other\n' > "$lock_file"
   assert_empty "$(bashdep::_lock_get "$lock_file" missing)"
+}
+
+# The name is matched as a literal, so a lockfile entry whose name contains
+# glob metacharacters resolves to itself rather than to whatever it matches.
+function test_bashdep_lock_get_treats_glob_chars_in_name_literally() {
+  local lock_file="$TEST_DIR/lock"
+  {
+    printf 'a*c\thttps://example.com/star\n'
+    printf 'abc\thttps://example.com/abc\n'
+  } > "$lock_file"
+
+  assert_equals "https://example.com/star" "$(bashdep::_lock_get "$lock_file" 'a*c')"
+}
+
+# Entries are anchored to the start of a line, so a name that is only a
+# suffix of a recorded name must not resolve.
+function test_bashdep_lock_get_does_not_match_a_name_suffix() {
+  local lock_file="$TEST_DIR/lock"
+  printf 'my-tool\thttps://example.com/my-tool\n' > "$lock_file"
+  assert_empty "$(bashdep::_lock_get "$lock_file" tool)"
+}
+
+# Malformed three-field lines still yield the second field only.
+function test_bashdep_lock_get_returns_second_field_only() {
+  local lock_file="$TEST_DIR/lock"
+  printf 'tool\thttps://example.com/tool\textra\n' > "$lock_file"
+  assert_equals "https://example.com/tool" "$(bashdep::_lock_get "$lock_file" tool)"
+}
+
+function test_bashdep_lock_get_reads_the_last_line_without_trailing_newline() {
+  local lock_file="$TEST_DIR/lock"
+  printf 'tool\thttps://example.com/tool' > "$lock_file"
+  assert_equals "https://example.com/tool" "$(bashdep::_lock_get "$lock_file" tool)"
 }
 
 function test_bashdep_lock_set_upserts_entry() {
@@ -1572,6 +1610,20 @@ function test_bashdep_cli_unknown_option_fails() {
   local stderr
   stderr=$(bashdep::main install --bogus 2>&1 >/dev/null)
   assert_contains "Unknown option" "$stderr"
+}
+
+function test_bashdep_cli_usage_documents_jobs_option() {
+  assert_contains "--jobs=N" "$(bashdep::main --help)"
+}
+
+function test_bashdep_cli_jobs_option_sets_job_count() {
+  BASHDEP_JOBS=4
+  bashdep::main --jobs=2 version >/dev/null
+  assert_equals "2" "$BASHDEP_JOBS"
+}
+
+function test_bashdep_completion_offers_jobs_flag() {
+  assert_contains "--jobs" "$(bashdep::completion bash)"
 }
 
 function test_bashdep_cli_install_url_dry_run_downloads_nothing() {


### PR DESCRIPTION
### 🔗 Ticket

<!-- No issue — dependency refresh + DX pass. -->

## 🤔 Background

bashunit had drifted 28 minor versions behind (`0.17.0`), and CI pulled two
actions from floating refs (`action-shellcheck@master`,
`action-editorconfig-checker@main`), so runs were not reproducible.

Separately, `BASHDEP_JOBS` — the only performance knob bashdep exposes —
was reachable **only** as an environment variable and was missing from
`--help`, making it effectively undiscoverable.

## 💡 Goal

Get dependencies current, make CI reproducible, and close the discoverability
gap on concurrency — without regressing runtime behavior.

## 🔖 Changes

### Dependencies

- bashunit `0.17.0` → `0.45.0`. **Suite runtime 26.8s → 2.5s (~11x).**
- Actions bumped: `checkout@v7`, `cache@v6`, `paths-filter@v4`,
  `configure-pages@v6`, `upload-pages-artifact@v5`, `deploy-pages@v5`.
- Floating refs pinned: `action-shellcheck@2.0.0`,
  `action-editorconfig-checker@v2.2.0`.
- `.bashunit/` (new run-state dir) git-ignored; `example/demo.sh` URL refreshed.

### Bug the upgrade exposed

bashunit ≥0.40 moved its doubles under `bashunit::mock` and changed the
multi-argument form to append `"$@"` to the mock body — so a body that reads
positional arguments (`touch "$3"`) can no longer be expressed. This suite
uses that shape in **62 of its 93 mocks**.

The failure was silent and dangerous: `mock` resolved to *command not found*,
the mocked tests fell through to **real network downloads**, and the run
overwrote `lib/bashunit` itself mid-suite.

`tests/bootstrap.sh` now owns `mock`/`unmock` with the semantics the suite was
written against. Each bashunit test runs in its own subshell, so the helpers
need no mock registry and depend on no bashunit internals.

### DX

- `--jobs=N` and `bashdep::setup jobs=N`, listed in `--help` and offered by the
  bash/zsh completion scripts.
- Validation deliberately stays in one place: like the env var, a non-integer
  warns and falls back to `4` when `install` runs, so all three entry points
  behave identically.
- `bashdep::_sha256` caches the `shasum`/`sha256sum` probe in
  `BASHDEP_SHA_TOOL`, mirroring how `BASHDEP_DOWNLOADER` already pins
  `curl`/`wget` for a whole run.

## 🖼️ Screenshots

N/A — CLI change. `--help` gains one line:

```
  --jobs=N              Concurrent downloads (default: 4, 1 = sequential)
```

---

## ⚠️ On "optimize for perf" — two claims measured and withdrawn

**1. Lockfile readers rewritten to pure bash, then reverted.**
Replacing the `awk` fork in `_lock_get`/`_lock_names` with builtin string
matching removes a fork per dependency — but bash re-scans the whole lockfile
on every lookup, so it goes quadratic:

| deps | before | after |
|------|--------|-------|
| 25   | 0.10s  | 0.06s |
| 100  | 0.38s  | 0.61s |
| 200  | 0.76s  | **3.32s** |

Crossover ~50 entries. Winning ~50ms on small projects in exchange for a silent
cliff on large ones is a bad trade. **Reverted**, with a comment in
`_lock_get` so nobody retries it. Final state is at parity (200 deps: 0.83s vs
0.86s).

**2. `_sha256` "drops an awk fork" — it doesn't.**
The inner `$(...)` just trades one fork for another. Measured identical (150
digests: 1.51s before and after). Kept for the tool-caching consistency, and
labeled in the CHANGELOG as a consistency change rather than a speedup.

Also dropped a `BASHDEP_JOBS_OUT` global I had added — it saved one fork per
`install` and was not worth the API surface.

**Net:** the real perf win here is the 11x faster test suite. `bashdep` itself
is unchanged in speed; no runtime optimization survived measurement, and
`install` is network-bound regardless.

## ✅ Verification

- 252 tests green, ShellCheck clean, editorconfig clean (`make pre_commit/run`)
- Verified on macOS default bash **3.2.57** (the compatibility floor)
- No network access from the suite; `lib/` stays clean across runs
