### PR TITLE
docs(changelog): tighten unreleased notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,34 +6,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [S
 
 ### Added
 
-- Concurrency is now configurable without touching the environment:
-  `bashdep::setup jobs=N` and the CLI's `--jobs=N` both set
-  `BASHDEP_JOBS`. The flag is listed in `--help` and offered by the
-  `bash`/`zsh` completion scripts. Validation is unchanged — a
-  non-integer warns and falls back to `4` when `install` runs.
+- `--jobs=N` and `bashdep::setup jobs=N` set the download concurrency previously reachable only through the `BASHDEP_JOBS` environment variable. Both appear in `--help` and in the `bash`/`zsh` completions.
 
 ### Changed
 
-- `bashdep::_sha256` resolves `shasum`/`sha256sum` once per run (cached
-  in `BASHDEP_SHA_TOOL`) instead of re-probing on every call, mirroring
-  how `BASHDEP_DOWNLOADER` already pins `curl`/`wget` for a whole run, so
-  every checksum in a run is computed by the same tool. It also slices
-  the digest with parameter expansion, which keeps `awk` out of that
-  path. Measured as performance-neutral (150 digests: 1.51s before and
-  after) — this is a consistency change, not a speedup.
-- Development dependency: bashunit `0.17.0` → `0.45.0`, which cuts the
-  suite's runtime from ~27s to ~2.5s. bashunit moved its doubles to
-  `bashunit::mock` and changed the multi-argument form to append `"$@"`
-  to the mock body, which cannot express a body that reads positional
-  arguments; `tests/bootstrap.sh` now defines the `mock`/`unmock` helpers
-  the suite relies on.
-- CI actions pinned and bumped: `checkout@v7`, `cache@v6`,
-  `paths-filter@v4`, `configure-pages@v6`, `upload-pages-artifact@v5`,
-  `deploy-pages@v5`, and the two previously floating refs
-  (`action-shellcheck@master`, `action-editorconfig-checker@main`) now
-  pin to `2.0.0` and `v2.2.0` for reproducible runs.
-
-### Fixed
+- Dev dependency: bashunit `0.17.0` → `0.45.0`, cutting the suite from ~27s to ~2.5s. `mock`/`unmock` now live in `tests/bootstrap.sh`, because bashunit's new doubles API cannot express a mock body that reads positional arguments.
+- `bashdep::_sha256` resolves `shasum`/`sha256sum` once per run rather than probing on every call, so all checksums in a run use the same tool — matching how `BASHDEP_DOWNLOADER` already pins `curl`/`wget`.
+- CI actions bumped, and `action-shellcheck`/`action-editorconfig-checker` pinned off floating refs so runs are reproducible.
 
 ## [0.8.1] - 2026-07-24
 


### PR DESCRIPTION
### 🔗 Ticket

<!-- Follow-up to #64. -->

## 🤔 Background

The `## Unreleased` entries added in #64 carried the reasoning behind each change — benchmark numbers, the mechanics of bashunit's doubles API, the full list of bumped action versions. That detail belongs in the PR and commit history. In a changelog it buries what a reader actually wants: what changed for them.

They were also hard-wrapped at 80 columns, which makes diffs noisy — rewording one sentence reflows the whole paragraph.

## 💡 Goal

Make the Unreleased section scannable, and stop hard-wrapping markdown prose.

## 🔖 Changes

- Cut the three `### Changed` entries down to one line each, dropping benchmark figures and per-action version lists.
- Rewrote the `### Added` entry to lead with the flags rather than the motivation.
- Dropped the empty `### Fixed` heading, matching the convention 0.8.1 established.
- Unwrapped the prose. `.editorconfig` sets `max_line_length` for `**.sh` (120) only and never for `**.md`, so long lines pass `make lint` — confirmed locally.

Net: 30 lines to 9, with no information a changelog reader needs removed.

## 🖼️ Screenshots

**BEFORE**

```
### Changed

- `bashdep::_sha256` resolves `shasum`/`sha256sum` once per run (cached
  in `BASHDEP_SHA_TOOL`) instead of re-probing on every call, mirroring
  how `BASHDEP_DOWNLOADER` already pins `curl`/`wget` for a whole run, so
  every checksum in a run is computed by the same tool. It also slices
  the digest with parameter expansion, which keeps `awk` out of that
  path. Measured as performance-neutral (150 digests: 1.51s before and
  after) — this is a consistency change, not a speedup.
```

**AFTER**

```
### Changed

- `bashdep::_sha256` resolves `shasum`/`sha256sum` once per run rather than probing on every call, so all checksums in a run use the same tool — matching how `BASHDEP_DOWNLOADER` already pins `curl`/`wget`.
```

## ✅ Verification

`make lint` clean. Documentation only — no code touched, so the tests and ShellCheck jobs skip via the existing paths filter.
