### PR TITLE
docs: correct stale toolchain version and unwrap prose

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,12 +1,10 @@
 # Contributing
 
-Thanks for considering a contribution. This guide covers project layout,
-how to run the suite, and the conventions we follow.
+Thanks for considering a contribution. This guide covers project layout, how to run the suite, and the conventions we follow.
 
 ## Code of Conduct
 
-This project follows a [Contributor Code of Conduct](CODE_OF_CONDUCT.md).
-By participating you agree to abide by its terms.
+This project follows a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By participating you agree to abide by its terms.
 
 ## License
 
@@ -25,9 +23,7 @@ docs/                       # API + behavior + releasing reference
 Makefile                    # test / sa / lint / deps / release / pre_commit/install
 ```
 
-The codebase is intentionally small and zero-runtime: only `curl` (or
-`wget`), `awk`, `mktemp`, and POSIX-ish utilities at runtime. Tests run
-on bash 3.2+ (default macOS) and bash 4+ (Linux CI).
+The codebase is intentionally small and zero-runtime: only `curl` (or `wget`), `awk`, `mktemp`, and POSIX-ish utilities at runtime. Tests run on bash 3.2+ (default macOS) and bash 4+ (Linux CI).
 
 ## Toolchain
 
@@ -35,12 +31,11 @@ Install these to run the full gate locally:
 
 | Tool | Purpose | Install |
 | --- | --- | --- |
-| [bashunit](https://bashunit.typeddevs.com/) `0.17.0` | Test runner | `make deps` |
+| [bashunit](https://bashunit.typeddevs.com/) `0.45.0` | Test runner | `make deps` |
 | [ShellCheck](https://www.shellcheck.net/) | Static analysis (`make sa`) | `brew install shellcheck` / `apt install shellcheck` |
 | [editorconfig-checker](https://editorconfig-checker.github.io/) | Whitespace/indent lint (`make lint`) | `brew install editorconfig-checker` |
 
-`make lint` finds the linter under either the `ec` or
-`editorconfig-checker` binary name.
+`make lint` finds the linter under either the `ec` or `editorconfig-checker` binary name.
 
 ## Workflow for pull requests
 
@@ -49,13 +44,9 @@ Install these to run the full gate locally:
 3. Run `make check` (test + ShellCheck + editorconfig).
 4. Open the PR with a short summary and a test plan.
 
-Prefer commit-time enforcement? Either `make pre_commit/install` (a
-plain git hook) or, with the [pre-commit](https://pre-commit.com)
-framework, `pip install pre-commit && pre-commit install` — the
-committed `.pre-commit-config.yaml` runs the same Makefile gates.
+Prefer commit-time enforcement? Either `make pre_commit/install` (a plain git hook) or, with the [pre-commit](https://pre-commit.com) framework, `pip install pre-commit && pre-commit install` — the committed `.pre-commit-config.yaml` runs the same Makefile gates.
 
-Set your git `user.name` / `user.email` so commit history stays clean:
-see [first-time setup](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup).
+Set your git `user.name` / `user.email` so commit history stays clean: see [first-time setup](https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup).
 
 ## Bug reports
 
@@ -86,11 +77,8 @@ Conventions in `tests/unit/bashdep_test.sh`:
 
 - One test per behavior. Names describe the assertion (`test_bashdep_…`).
 - Pure-logic tests (no filesystem) sit at the top of the file.
-- Filesystem tests use `$TEST_DIR` (a `mktemp -d` set up in `set_up`,
-  cleaned in `tear_down`). Use the `_seed_lock` / `_seed_installed`
-  helpers to scaffold lockfile fixtures.
-- Snapshot tests keep hardcoded `/tmp/test_<name>` paths because the
-  snapshot embeds the path. Don't migrate those to `$TEST_DIR`.
+- Filesystem tests use `$TEST_DIR` (a `mktemp -d` set up in `set_up`, cleaned in `tear_down`). Use the `_seed_lock` / `_seed_installed` helpers to scaffold lockfile fixtures.
+- Snapshot tests keep hardcoded `/tmp/test_<name>` paths because the snapshot embeds the path. Don't migrate those to `$TEST_DIR`.
 
 ## Coding guidelines
 
@@ -102,8 +90,7 @@ Install: <https://github.com/koalaman/shellcheck#installing>
 make sa
 ```
 
-`make sa` discovers scripts via `find` and matches CI scope: `bashdep`,
-`bin/pre-commit`, and every `*.sh` outside `vendor/`, `lib/`, `local/`.
+`make sa` discovers scripts via `find` and matches CI scope: `bashdep`, `bin/pre-commit`, and every `*.sh` outside `vendor/`, `lib/`, `local/`.
 
 ### editorconfig-checker
 
@@ -125,8 +112,4 @@ Runs `make pre_commit/run` (test + sa + lint) on every commit.
 
 ### Style
 
-We follow Google's
-[Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
-where it doesn't conflict with this repo's conventions:
-`function name() { … }`, snake_case, and the `bashdep::` namespace
-prefix on every public function.
+We follow Google's [Shell Style Guide](https://google.github.io/styleguide/shellguide.html) where it doesn't conflict with this repo's conventions: `function name() { … }`, snake_case, and the `bashdep::` namespace prefix on every public function.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,12 @@
 # bashdep
 
-[![Release](https://img.shields.io/github/v/release/Chemaclass/bashdep?sort=semver)](https://github.com/Chemaclass/bashdep/releases/latest)
-[![CI](https://github.com/Chemaclass/bashdep/actions/workflows/ci.yml/badge.svg)](https://github.com/Chemaclass/bashdep/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Release](https://img.shields.io/github/v/release/Chemaclass/bashdep?sort=semver)](https://github.com/Chemaclass/bashdep/releases/latest) [![CI](https://github.com/Chemaclass/bashdep/actions/workflows/ci.yml/badge.svg)](https://github.com/Chemaclass/bashdep/actions/workflows/ci.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Minimal, zero-dependency **bash dependency manager**. Declare URLs;
-bashdep downloads them into `lib/` and keeps installs idempotent via a
-per-directory `.bashdep.lock`. No registry, no runtime — just `curl`
-(or `wget`).
+Minimal, zero-dependency **bash dependency manager**. Declare URLs; bashdep downloads them into `lib/` and keeps installs idempotent via a per-directory `.bashdep.lock`. No registry, no runtime — just `curl` (or `wget`).
 
 ## Quick start
 
-**1. Vendor bashdep into your repo** (pinned release, verified against
-its published `checksum` — recommended for reproducibility):
+**1. Vendor bashdep into your repo** (pinned release, verified against its published `checksum` — recommended for reproducibility):
 
 ```bash
 mkdir -p lib
@@ -21,17 +15,14 @@ curl -fsSLo checksum     https://github.com/Chemaclass/bashdep/releases/latest/d
 ( cd lib && shasum -a 256 -c ../checksum ) && chmod +x lib/bashdep
 ```
 
-Prefer the bleeding edge? Grab the `main` branch instead (unversioned,
-no checksum):
+Prefer the bleeding edge? Grab the `main` branch instead (unversioned, no checksum):
 
 ```bash
 curl -fsSLo lib/bashdep https://raw.githubusercontent.com/Chemaclass/bashdep/main/bashdep
 chmod +x lib/bashdep
 ```
 
-**2. Declare your dependencies in a `.bashdep` file** (one URL per
-line; `#` comments allowed; `@dev` suffix routes to `lib/dev/`;
-optional `#sha256=<hex>` verifies the download):
+**2. Declare your dependencies in a `.bashdep` file** (one URL per line; `#` comments allowed; `@dev` suffix routes to `lib/dev/`; optional `#sha256=<hex>` verifies the download):
 
 ```
 https://github.com/TypedDevs/bashunit/releases/download/0.17.0/bashunit
@@ -46,10 +37,7 @@ https://example.com/pinned.sh#sha256=e3b0c44298fc1c149afbf4c8996fb924...
 ./lib/bashdep install
 ```
 
-That's it. The first run downloads everything and writes
-`.bashdep.lock`. Re-runs skip already-installed deps; bumping a URL
-version re-downloads only that entry. Commit `.bashdep.lock` to lock
-versions across collaborators.
+That's it. The first run downloads everything and writes `.bashdep.lock`. Re-runs skip already-installed deps; bumping a URL version re-downloads only that entry. Commit `.bashdep.lock` to lock versions across collaborators.
 
 Everyday commands:
 
@@ -64,8 +52,7 @@ Enable tab completion: `source <(./lib/bashdep completion bash)` (or `zsh`).
 
 ### Or source it from a script
 
-Prefer a programmatic setup (custom dirs, inline arrays)? Source
-bashdep and call the same functions:
+Prefer a programmatic setup (custom dirs, inline arrays)? Source bashdep and call the same functions:
 
 ```bash
 #!/bin/bash
@@ -75,50 +62,36 @@ source lib/bashdep
 bashdep::install_from   # reads ./.bashdep
 ```
 
-See the [API reference](docs/api.md) for `bashdep::setup`,
-`bashdep::install`, and friends.
+See the [API reference](docs/api.md) for `bashdep::setup`, `bashdep::install`, and friends.
 
 ### Exit codes for CI
 
-Every command returns a meaningful, capped-at-255 count, so it drops into
-CI as-is:
+Every command returns a meaningful, capped-at-255 count, so it drops into CI as-is:
 
 ```bash
 ./lib/bashdep doctor || echo "lockfile drift: $? issue(s)"   # 0 = clean
 ./lib/bashdep install || echo "$? download(s) failed"
 ```
 
-`install` returns the failure count, `doctor` the issue count, `clean`
-the number of orphans it could not remove, and `uninstall` the count of
-names not found. See [Behavior](docs/behavior.md#error-handling).
+`install` returns the failure count, `doctor` the issue count, `clean` the number of orphans it could not remove, and `uninstall` the count of names not found. See [Behavior](docs/behavior.md#error-handling).
 
 ## Why bashdep?
 
 - **Idempotent installs** via per-directory `.bashdep.lock`.
-- **Parallel downloads** — dependencies fetch concurrently (tune with
-  `--jobs=N`, `bashdep::setup jobs=N`, or `BASHDEP_JOBS`; default 4,
-  `1` for sequential).
-- **Optional integrity checks** — pin a dependency with `#sha256=<hex>`
-  and bashdep verifies the download before recording it.
+- **Parallel downloads** — dependencies fetch concurrently (tune with `--jobs=N`, `bashdep::setup jobs=N`, or `BASHDEP_JOBS`; default 4, `1` for sequential).
+- **Optional integrity checks** — pin a dependency with `#sha256=<hex>` and bashdep verifies the download before recording it.
 - **Dev/prod separation** via the `@dev` URL suffix (`lib/` vs `lib/dev/`).
 - **`curl` or `wget`** — uses whichever is installed.
-- **File-driven, array-driven, or CLI** — `install_from`, `install`, or
-  `./lib/bashdep <command>` (with `bash`/`zsh` tab completion).
-- **Lifecycle commands** — `list`, `uninstall`, `clean`, `doctor`,
-  `self_update`, `completion`.
+- **File-driven, array-driven, or CLI** — `install_from`, `install`, or `./lib/bashdep <command>` (with `bash`/`zsh` tab completion).
+- **Lifecycle commands** — `list`, `uninstall`, `clean`, `doctor`, `self_update`, `completion`.
 - **Modes** — `force`, `dry-run`, `silent`, `verbose`.
 
 ## Documentation
 
-- [**API reference**](docs/api.md) — the CLI plus `install`,
-  `install_from`, `setup`, `list`, `uninstall`, `clean`, `doctor`,
-  `self_update`, `completion`, `version`.
-- [**Behavior**](docs/behavior.md) — lockfile rules, dev dependencies,
-  checksum verification, parallel downloads, error handling, gotchas.
-- [**Releasing**](docs/releasing.md) — how maintainers cut a new tagged
-  release with `release.sh`.
-- [**Contributing**](.github/CONTRIBUTING.md) — project layout, test
-  conventions, coding guidelines.
+- [**API reference**](docs/api.md) — the CLI plus `install`, `install_from`, `setup`, `list`, `uninstall`, `clean`, `doctor`, `self_update`, `completion`, `version`.
+- [**Behavior**](docs/behavior.md) — lockfile rules, dev dependencies, checksum verification, parallel downloads, error handling, gotchas.
+- [**Releasing**](docs/releasing.md) — how maintainers cut a new tagged release with `release.sh`.
+- [**Contributing**](.github/CONTRIBUTING.md) — project layout, test conventions, coding guidelines.
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,7 @@
 # Documentation
 
 - [API reference](api.md) — every public `bashdep::*` function.
-- [Behavior](behavior.md) — lockfile rules, dev dependencies, checksum
-  verification, parallel downloads, error handling, gotchas.
-- [Releasing](releasing.md) — how to cut a new tagged release with
-  `release.sh`.
+- [Behavior](behavior.md) — lockfile rules, dev dependencies, checksum verification, parallel downloads, error handling, gotchas.
+- [Releasing](releasing.md) — how to cut a new tagged release with `release.sh`.
 
-For contribution workflow and project layout, see
-[`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md).
+For contribution workflow and project layout, see [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md).

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,6 @@
 # API reference
 
-Public functions exposed by `source lib/bashdep`. For lockfile rules,
-dev-dependency routing, and error semantics see [Behavior](behavior.md).
+Public functions exposed by `source lib/bashdep`. For lockfile rules, dev-dependency routing, and error semantics see [Behavior](behavior.md).
 
 - [CLI](#cli)
 - [`bashdep::install`](#bashdepinstall)
@@ -17,8 +16,7 @@ dev-dependency routing, and error semantics see [Behavior](behavior.md).
 
 ## CLI
 
-Every command is also available by executing the script directly —
-no `source` needed:
+Every command is also available by executing the script directly — no `source` needed:
 
 ```bash
 ./lib/bashdep install                      # install from ./.bashdep
@@ -32,22 +30,15 @@ no `source` needed:
 ./lib/bashdep --help
 ```
 
-Enable shell completion by sourcing the generated script, e.g. in
-`~/.bashrc`:
+Enable shell completion by sourcing the generated script, e.g. in `~/.bashrc`:
 
 ```bash
 source <(bashdep completion bash)
 ```
 
-Options map 1:1 to [`bashdep::setup`](#bashdepsetup) parameters:
-`--dir=DIR`, `--dev-dir=DIR`, `--jobs=N`, `--force`, `--dry-run`,
-`--silent`, `--verbose`. `install` also accepts `--file=FILE` to point
-at a dependency file other than `.bashdep`.
+Options map 1:1 to [`bashdep::setup`](#bashdepsetup) parameters: `--dir=DIR`, `--dev-dir=DIR`, `--jobs=N`, `--force`, `--dry-run`, `--silent`, `--verbose`. `install` also accepts `--file=FILE` to point at a dependency file other than `.bashdep`.
 
-`--version` prints the version and `-h`/`--help` prints usage. Exit codes
-match the underlying function's return value (e.g. `doctor` exits with
-the issue count), so the CLI drops into CI pipelines as-is. Sourcing the
-script never triggers the CLI.
+`--version` prints the version and `-h`/`--help` prints usage. Exit codes match the underlying function's return value (e.g. `doctor` exits with the issue count), so the CLI drops into CI pipelines as-is. Sourcing the script never triggers the CLI.
 
 ## `bashdep::install`
 
@@ -61,21 +52,11 @@ DEPENDENCIES=(
 bashdep::install "${DEPENDENCIES[@]}"
 ```
 
-Downloads run in parallel, up to `BASHDEP_JOBS` at a time (default `4`),
-which `bashdep::setup jobs=N` and the CLI's `--jobs=N` also set. Use `1`
-for sequential downloads. `BASHDEP_JOBS` must be a
-non-negative integer; any other value is rejected with a warning and the
-default of `4` is used. Append `#sha256=<hex>` to a URL to verify the
-download (see [Checksum verification](behavior.md#checksum-verification-opt-in)).
-Prints an `installed X, skipped Y, failed Z` summary (unless `silent`)
-and returns the number of failed downloads (0 on success, capped at 255).
+Downloads run in parallel, up to `BASHDEP_JOBS` at a time (default `4`), which `bashdep::setup jobs=N` and the CLI's `--jobs=N` also set. Use `1` for sequential downloads. `BASHDEP_JOBS` must be a non-negative integer; any other value is rejected with a warning and the default of `4` is used. Append `#sha256=<hex>` to a URL to verify the download (see [Checksum verification](behavior.md#checksum-verification-opt-in)). Prints an `installed X, skipped Y, failed Z` summary (unless `silent`) and returns the number of failed downloads (0 on success, capped at 255).
 
 ## `bashdep::install_from`
 
-Read a dependency list from a file and install every entry. One URL per
-line; blank lines and `#` comments are ignored; leading/trailing
-whitespace is stripped. Defaults to `.bashdep` in the current directory
-when called without arguments.
+Read a dependency list from a file and install every entry. One URL per line; blank lines and `#` comments are ignored; leading/trailing whitespace is stripped. Defaults to `.bashdep` in the current directory when called without arguments.
 
 ```bash
 bashdep::install_from            # reads ./.bashdep
@@ -93,46 +74,35 @@ https://github.com/Chemaclass/create-pr/releases/download/0.6/create-pr
 https://github.com/Chemaclass/bash-dumper/releases/download/0.1/dumper.sh@dev
 ```
 
-Returns `1` if the file is missing or unreadable; otherwise propagates
-the failure count from `bashdep::install`.
+Returns `1` if the file is missing or unreadable; otherwise propagates the failure count from `bashdep::install`.
 
 ## `bashdep::uninstall`
 
-Remove one or more installed dependencies. Searches `dir` and `dev-dir`,
-deletes the file, and drops the matching `.bashdep.lock` entry. The
-lockfile is removed once it has no entries left.
+Remove one or more installed dependencies. Searches `dir` and `dev-dir`, deletes the file, and drops the matching `.bashdep.lock` entry. The lockfile is removed once it has no entries left.
 
 ```bash
 bashdep::uninstall create-pr dumper.sh
 ```
 
-Returns the number of names not found (0 on full success). In dry-run
-mode, prints intended actions without touching disk.
+Returns the number of names not found (0 on full success). In dry-run mode, prints intended actions without touching disk.
 
 ## `bashdep::clean`
 
-Remove orphan files in each managed directory: anything not recorded in
-`.bashdep.lock` (and not the lockfile itself). Directories without a
-lockfile are left alone — bashdep treats a missing lockfile as "this
-dir is unmanaged".
+Remove orphan files in each managed directory: anything not recorded in `.bashdep.lock` (and not the lockfile itself). Directories without a lockfile are left alone — bashdep treats a missing lockfile as "this dir is unmanaged".
 
 ```bash
 bashdep::clean
 ```
 
-Returns 0 when every orphan was removed, otherwise the number of orphans
-that could not be removed (e.g. a permission error), capped at 255. A
-failed removal is reported to stderr. Honors dry-run mode.
+Returns 0 when every orphan was removed, otherwise the number of orphans that could not be removed (e.g. a permission error), capped at 255. A failed removal is reported to stderr. Honors dry-run mode.
 
 ## `bashdep::doctor`
 
-Check each managed directory for inconsistencies. Reports three kinds of
-issues:
+Check each managed directory for inconsistencies. Reports three kinds of issues:
 
 - Lockfile entries whose file is missing on disk.
 - Files on disk with no lockfile entry.
-- Malformed lockfile lines (not exactly two tab-separated fields), which
-  catches merge-conflict or hand-edit damage.
+- Malformed lockfile lines (not exactly two tab-separated fields), which catches merge-conflict or hand-edit damage.
 
 ```bash
 bashdep::doctor
@@ -142,22 +112,18 @@ bashdep::doctor
 # doctor: 2 issue(s) found
 ```
 
-Returns the issue count (capped at 255). Useful in CI to catch lockfile
-drift after manual edits or merge conflicts.
+Returns the issue count (capped at 255). Useful in CI to catch lockfile drift after manual edits or merge conflicts.
 
 ## `bashdep::self_update`
 
-Re-download the bashdep script itself from upstream and replace the
-local copy via an atomic `mv`. Defaults to the `main` branch.
+Re-download the bashdep script itself from upstream and replace the local copy via an atomic `mv`. Defaults to the `main` branch.
 
 ```bash
 bashdep::self_update            # main branch
 bashdep::self_update 0.4.0      # specific tag/branch
 ```
 
-The download URL is built from `BASHDEP_SELF_URL_TEMPLATE` (a printf
-format string with one `%s` slot for the ref). After updating, re-source
-the script to load the new version. Honors dry-run mode.
+The download URL is built from `BASHDEP_SELF_URL_TEMPLATE` (a printf format string with one `%s` slot for the ref). After updating, re-source the script to load the new version. Honors dry-run mode.
 
 ## `bashdep::setup`
 
@@ -177,17 +143,11 @@ Configure defaults before calling `install`. All parameters are optional.
 bashdep::setup dir="vendor" dev-dir="src/dev" silent=true force=false
 ```
 
-Invalid values (unknown param, non-boolean for `silent`/`force`) cause
-`setup` to print an error to stderr and return `1`. `jobs` is not
-validated here — like the `BASHDEP_JOBS` environment variable it is
-checked when `install` runs, where a non-integer warns and falls back
-to `4`.
+Invalid values (unknown param, non-boolean for `silent`/`force`) cause `setup` to print an error to stderr and return `1`. `jobs` is not validated here — like the `BASHDEP_JOBS` environment variable it is checked when `install` runs, where a non-integer warns and falls back to `4`.
 
 ## `bashdep::list`
 
-Print every installed dependency recorded in the lockfiles under `dir`
-and `dev-dir`. One entry per line, tab-separated: `<path>\t<source URL>`.
-Pass extra directories as positional arguments to include them too.
+Print every installed dependency recorded in the lockfiles under `dir` and `dev-dir`. One entry per line, tab-separated: `<path>\t<source URL>`. Pass extra directories as positional arguments to include them too.
 
 ```bash
 $ bashdep::list
@@ -200,8 +160,7 @@ Pipe into `awk` / `cut` for audit and diff tooling.
 
 ## `bashdep::completion`
 
-Print a shell completion script for the CLI commands and flags. Accepts
-`bash` (default) or `zsh`; returns `1` for any other shell.
+Print a shell completion script for the CLI commands and flags. Accepts `bash` (default) or `zsh`; returns `1` for any other shell.
 
 ```bash
 source <(bashdep completion bash)   # or: bashdep completion zsh

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -1,8 +1,6 @@
 # Behavior
 
-How bashdep decides what to download, where to put it, and when to
-skip. For function signatures and the CLI see the
-[API reference](api.md).
+How bashdep decides what to download, where to put it, and when to skip. For function signatures and the CLI see the [API reference](api.md).
 
 - [Lockfile and idempotency](#lockfile-and-idempotency)
 - [Dev dependencies](#dev-dependencies)
@@ -12,9 +10,7 @@ skip. For function signatures and the CLI see the
 
 ## Lockfile and idempotency
 
-`bashdep::install` is idempotent **per source URL**, not per filename.
-Each destination directory gets a `.bashdep.lock` recording the URL of
-every dependency installed there:
+`bashdep::install` is idempotent **per source URL**, not per filename. Each destination directory gets a `.bashdep.lock` recording the URL of every dependency installed there:
 
 ```
 # lib/.bashdep.lock
@@ -31,15 +27,11 @@ create-pr	https://github.com/Chemaclass/create-pr/releases/download/0.6/create-p
 |      no      |        —         |    —    | re-download |
 |     yes      |       yes        |   yes   | re-download |
 
-Bumping a release in the URL (`0.17.0` → `0.18.0`) re-downloads the
-affected entry only; nothing else is touched.
+Bumping a release in the URL (`0.17.0` → `0.18.0`) re-downloads the affected entry only; nothing else is touched.
 
 ### Recommended workflow
 
-Commit `.bashdep.lock` alongside your install script so collaborators
-get the same versions you do. Rotate by editing the URL in your
-dependency list (or `.bashdep` file) and re-running install — the
-lockfile updates automatically.
+Commit `.bashdep.lock` alongside your install script so collaborators get the same versions you do. Rotate by editing the URL in your dependency list (or `.bashdep` file) and re-running install — the lockfile updates automatically.
 
 ## Dev dependencies
 
@@ -52,48 +44,27 @@ DEPENDENCIES=(
 )
 ```
 
-Each directory keeps its own `.bashdep.lock`. `bashdep::list` reads
-both by default.
+Each directory keeps its own `.bashdep.lock`. `bashdep::list` reads both by default.
 
 ## Checksum verification (opt-in)
 
-Append `#sha256=<hex>` to a dependency URL to have bashdep verify the
-download's SHA-256 before recording it:
+Append `#sha256=<hex>` to a dependency URL to have bashdep verify the download's SHA-256 before recording it:
 
 ```
 https://example.com/tool.sh#sha256=e3b0c44298fc1c149afbf4c8996fb924...
 https://example.com/dev-tool.sh@dev#sha256=2c26b46b68ffc68ff99b453c...
 ```
 
-The annotation is stripped before download (`curl`/`wget` never see it)
-and can combine with the `@dev` suffix. On a mismatch — or when neither
-`shasum` nor `sha256sum` is available — the download fails, the file is
-removed, and no lockfile entry is written. A present-but-empty or
-non-hex annotation (e.g. `#sha256=`) is rejected before download rather
-than silently skipping the check. Without the annotation, nothing is
-verified (the default).
+The annotation is stripped before download (`curl`/`wget` never see it) and can combine with the `@dev` suffix. On a mismatch — or when neither `shasum` nor `sha256sum` is available — the download fails, the file is removed, and no lockfile entry is written. A present-but-empty or non-hex annotation (e.g. `#sha256=`) is rejected before download rather than silently skipping the check. Without the annotation, nothing is verified (the default).
 
 ## Error handling
 
-- `bashdep::install` downloads in parallel (up to `BASHDEP_JOBS`, default
-  `4`; use `1` for sequential). `BASHDEP_JOBS` is also settable via
-  `bashdep::setup jobs=N` or the CLI's `--jobs=N`. It must be a
-  non-negative integer; a non-numeric or otherwise invalid value is
-  rejected with a warning and the default of `4` is used. It continues
-  past failed downloads and returns the failure count (capped at 255).
-  Lockfile writes are batched into a single rewrite per directory after
-  all downloads finish, so concurrency never corrupts the lockfile.
-- `bashdep::install_from` returns `1` if the file (default: `.bashdep`)
-  is missing or unreadable.
-- `bashdep::setup` returns `1` on unknown params or non-boolean values
-  for `silent` / `force`.
-- `bashdep::clean` returns the number of orphans it could not remove
-  (capped at 255), reporting each failed removal to stderr; `0` when all
-  orphans were removed.
-- Downloads use `curl` when available and fall back to `wget`; if neither
-  is installed the download fails with exit `127`.
-- Download failures print the downloader's exit code to stderr (e.g. curl
-  `22` = HTTP error, `6` = DNS, `7` = connect refused).
+- `bashdep::install` downloads in parallel (up to `BASHDEP_JOBS`, default `4`; use `1` for sequential). `BASHDEP_JOBS` is also settable via `bashdep::setup jobs=N` or the CLI's `--jobs=N`. It must be a non-negative integer; a non-numeric or otherwise invalid value is rejected with a warning and the default of `4` is used. It continues past failed downloads and returns the failure count (capped at 255). Lockfile writes are batched into a single rewrite per directory after all downloads finish, so concurrency never corrupts the lockfile.
+- `bashdep::install_from` returns `1` if the file (default: `.bashdep`) is missing or unreadable.
+- `bashdep::setup` returns `1` on unknown params or non-boolean values for `silent` / `force`.
+- `bashdep::clean` returns the number of orphans it could not remove (capped at 255), reporting each failed removal to stderr; `0` when all orphans were removed.
+- Downloads use `curl` when available and fall back to `wget`; if neither is installed the download fails with exit `127`.
+- Download failures print the downloader's exit code to stderr (e.g. curl `22` = HTTP error, `6` = DNS, `7` = connect refused).
 
 Pair with `set -euo pipefail` and `|| exit $?` to fail fast:
 
@@ -109,16 +80,6 @@ bashdep::install_from .bashdep || exit $?
 
 Known boundaries of the flat, URL-driven model — by design, not bugs:
 
-- **A dependency's identity is its filename** — the last path segment of
-  the URL. Two URLs ending in the same basename (`.../v1/util.sh` and
-  `.../v2/util.sh`) resolve to the same file in the same directory: the
-  second overwrites the first and the lockfile keeps a single entry.
-  Disambiguate by routing one to `@dev`, pointing it at another `dir`, or
-  renaming upstream.
-- **The lockfile pins the source URL, not a checksum.** Idempotency and
-  `doctor` drift detection compare URLs; integrity is enforced only when
-  you add an explicit `#sha256=` annotation, which is re-checked on every
-  download.
-- **No transitive resolution.** bashdep installs exactly the URLs you
-  list — a dependency cannot declare its own dependencies. List the full
-  set yourself.
+- **A dependency's identity is its filename** — the last path segment of the URL. Two URLs ending in the same basename (`.../v1/util.sh` and `.../v2/util.sh`) resolve to the same file in the same directory: the second overwrites the first and the lockfile keeps a single entry. Disambiguate by routing one to `@dev`, pointing it at another `dir`, or renaming upstream.
+- **The lockfile pins the source URL, not a checksum.** Idempotency and `doctor` drift detection compare URLs; integrity is enforced only when you add an explicit `#sha256=` annotation, which is re-checked on every download.
+- **No transitive resolution.** bashdep installs exactly the URLs you list — a dependency cannot declare its own dependencies. List the full set yourself.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,16 +1,8 @@
 # Releasing
 
-bashdep ships a single `bashdep` script. Releases are git tags + a
-GitHub release with two downloadable assets: the `bashdep` script and a
-`checksum` (sha256) to verify it. The whole flow is automated by
-`release.sh`.
+bashdep ships a single `bashdep` script. Releases are git tags + a GitHub release with two downloadable assets: the `bashdep` script and a `checksum` (sha256) to verify it. The whole flow is automated by `release.sh`.
 
-The root `release.sh` is a thin wrapper: it runs the reusable, project-
-agnostic engine in [`templates/release.sh`](../templates/release.sh),
-configured by [`release.conf`](../release.conf) (version read/write, gate,
-assets, release notes). bashdep **dogfoods** the same template it offers
-other projects — see [templates/README.md](../templates/README.md) to
-reuse it in your own repo.
+The root `release.sh` is a thin wrapper: it runs the reusable, project- agnostic engine in [`templates/release.sh`](../templates/release.sh), configured by [`release.conf`](../release.conf) (version read/write, gate, assets, release notes). bashdep **dogfoods** the same template it offers other projects — see [templates/README.md](../templates/README.md) to reuse it in your own repo.
 
 ## Cutting a release
 
@@ -18,12 +10,9 @@ Prerequisites:
 
 - On `main`, working tree clean.
 - `gh` CLI authenticated (`gh auth status`).
-- ShellCheck and editorconfig-checker installed (release script gates
-  on them).
+- ShellCheck and editorconfig-checker installed (release script gates on them).
 
-By default, the script auto-bumps the **minor** version (e.g. `0.3.0` →
-`0.4.0`). Pass an explicit version to override, or use `--major` /
-`--patch` for a different bump level.
+By default, the script auto-bumps the **minor** version (e.g. `0.3.0` → `0.4.0`). Pass an explicit version to override, or use `--major` / `--patch` for a different bump level.
 
 Preview first (idempotent — touches nothing):
 
@@ -66,12 +55,9 @@ The script:
 8. Creates the GitHub release via `gh release create`, uploads `bashdep`
     + `checksum`, and verifies both assets attached.
 
-The release URL is printed at the end. If any step **before the commit**
-fails, the script auto-reverts the file mutations and removes `dist/`;
-after the commit it prints the exact recovery command instead.
+The release URL is printed at the end. If any step **before the commit** fails, the script auto-reverts the file mutations and removes `dist/`; after the commit it prints the exact recovery command instead.
 
-The `dist/` build directory is git-ignored — it is a release artifact,
-not source.
+The `dist/` build directory is git-ignored — it is a release artifact, not source.
 
 ## Flags
 

--- a/site/index.html
+++ b/site/index.html
@@ -244,7 +244,7 @@ Downloading 'dumper.sh' <span class="d">→ lib/dev/</span>
               <li>Idempotent per source URL via <code>.bashdep.lock</code></li>
               <li>The lockfile records every file's origin</li>
               <li>Opt-in <code>#sha256=</code> integrity verification</li>
-              <li>Parallel downloads, tuned by <code>BASHDEP_JOBS</code></li>
+              <li>Parallel downloads, tuned by <code>--jobs=N</code></li>
               <li><code>@dev</code> suffix routes tools to <code>lib/dev/</code></li>
             </ul>
           </div>
@@ -260,7 +260,7 @@ Downloading 'dumper.sh' <span class="d">→ lib/dev/</span>
           <code>curl</code>/<code>wget</code>, <code>awk</code>, and POSIX builtins.</p>
         <div class="grid">
           <div class="feat"><div class="ix">01</div><h3>idempotent lockfile</h3><p>Per-directory <code>.bashdep.lock</code> records each URL; re-runs skip unchanged deps, a URL bump re-downloads only that entry.</p></div>
-          <div class="feat"><div class="ix">02</div><h3>parallel downloads</h3><p>Fetch concurrently (default 4, set <code>BASHDEP_JOBS</code>). Lockfile writes batch into one atomic rewrite per dir.</p></div>
+          <div class="feat"><div class="ix">02</div><h3>parallel downloads</h3><p>Fetch concurrently (default 4, set <code>--jobs=N</code> or <code>BASHDEP_JOBS</code>). Lockfile writes batch into one atomic rewrite per dir.</p></div>
           <div class="feat"><div class="ix">03</div><h3>checksum verify</h3><p>Append <code>#sha256=&lt;hex&gt;</code> to any URL; a mismatch fails the install and leaves no file or lockfile entry.</p></div>
           <div class="feat"><div class="ix">04</div><h3>dev / prod split</h3><p>The <code>@dev</code> suffix routes a dependency to <code>lib/dev/</code>, keeping runtime and tooling apart.</p></div>
           <div class="feat"><div class="ix">05</div><h3>curl or wget</h3><p>Uses whichever is installed, preferring <code>curl</code> and falling back to <code>wget</code> automatically.</p></div>
@@ -285,7 +285,7 @@ Downloading 'dumper.sh' <span class="d">→ lib/dev/</span>
  │  declare │──▶│  route   │──▶│ curl │ wget  │─▶│  sha256  │──▶│  atomic write │
  │  urls    │   │  dir     │   │ in parallel  │  │  reject≠ │   │  one per dir  │
  └──────────┘   └──────────┘   └──────────────┘  └──────────┘   └───────────────┘
-   <span class="l">@dev</span>            <span class="l">strip</span>          <span class="l">BASHDEP_JOBS</span>     <span class="l">#sha256=</span>       <span class="l">commit .lock</span></pre>
+   <span class="l">@dev</span>            <span class="l">strip</span>          <span class="l">--jobs=N</span>         <span class="l">#sha256=</span>       <span class="l">commit .lock</span></pre>
 <!-- editorconfig-checker-enable -->
         </div>
 


### PR DESCRIPTION
### 🔗 Ticket

<!-- Follow-up to #64 / #65. -->

## 🤔 Background

Two real defects surfaced while auditing the docs after #64:

- `CONTRIBUTING.md` still pinned bashunit `0.17.0` in the toolchain table. The repo moved to `0.45.0` in #64, so a contributor matching that table would install a version whose doubles API the suite no longer targets — exactly the failure #64 was about.
- The landing page advertised concurrency as `BASHDEP_JOBS` only, predating the `--jobs=N` flag.

Separately, all prose was hard-wrapped at 80 columns, which makes documentation diffs noisy: rewording one sentence reflows the entire paragraph.

## 💡 Goal

Make the docs accurate against the current code, and stop hard-wrapping markdown prose.

## 🔖 Changes

- `CONTRIBUTING.md`: bashunit `0.17.0` → `0.45.0` in the toolchain table.
- `site/index.html`: the feature list, the feature card, and the pipeline diagram now name `--jobs=N` alongside `BASHDEP_JOBS`. Diagram column alignment preserved.
- Unwrapped prose in `README.md`, `docs/api.md`, `docs/behavior.md`, `docs/README.md`, `docs/releasing.md`, `.github/CONTRIBUTING.md`.

The unwrap was scripted with code fences, tables, blockquotes, headings, indented blocks and list-item boundaries all protected, then diff-reviewed. Only prose lines were joined — no wording changed, nothing reordered, no content removed.

## 🖼️ Screenshots

**BEFORE**

```
- `bashdep::clean` returns the number of orphans it could not remove
  (capped at 255), reporting each failed removal to stderr; `0` when all
  orphans were removed.
```

**AFTER**

```
- `bashdep::clean` returns the number of orphans it could not remove (capped at 255), reporting each failed removal to stderr; `0` when all orphans were removed.
```

## ✅ Verification

- `make check` clean: 252 tests, ShellCheck, editorconfig
- `.editorconfig` sets `max_line_length` for `**.sh` (120) only, never for `**.md`, so the long lines lint clean
- Tables, code blocks and multi-line bullets spot-checked in every touched file
